### PR TITLE
feat: 관리자용 사용자 목록 검색 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
@@ -2,7 +2,9 @@ package com.flexrate.flexrate_back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FlexrateBackApplication {
 

--- a/src/main/java/com/flexrate/flexrate_back/common/config/QuerydslConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.flexrate.flexrate_back.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/common/dto/PaginationInfo.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/dto/PaginationInfo.java
@@ -1,0 +1,8 @@
+package com.flexrate.flexrate_back.common.dto;
+
+public record PaginationInfo(
+        int currentPage,
+        int pageSize,
+        int totalPages,
+        long totalElements
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN("A004", "유효하지 않은 리프레시 토큰입니다."),
     INVALID_EMAIL_FORMAT("A005", "올바르지 않은 이메일 형식입니다."),
     AUTHENTICATION_REQUIRED("A006", "인증이 필요합니다."),
+    ADMIN_AUTH_REQUIRED("A007", "관리자 권한이 필요합니다."),
 
     // 상품
     PRODUCT_LOAD_ERROR("P001", "상품을 불러오는 중 오류가 발생했습니다."),
@@ -34,7 +35,10 @@ public enum ErrorCode {
 
     // 서버 오류
     INTERNAL_SERVER_ERROR("S500", "서버 내부 오류"),
-    NOT_FOUND_STATIC_RESOURCE("S404", "요청한 정적 리소스를 찾을 수 없습니다.");
+    NOT_FOUND_STATIC_RESOURCE("S404", "요청한 정적 리소스를 찾을 수 없습니다."),
+
+    // 유효성
+    VALIDATION_ERROR("V001", "유효성 검사 오류");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/FlexrateException.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/FlexrateException.java
@@ -1,7 +1,6 @@
 package com.flexrate.flexrate_back.common.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * FLEXRATE 커스텀 예외

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/GlobalExceptionHandler.java
@@ -8,14 +8,35 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
     private final ProfileUtil profileUtil;
+
+    /**
+     * Validation 에러 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        List<String> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        ErrorResponse errorResponse = new ErrorResponse("V001", String.join(", ", errors));
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
 
     /**
      * 404 에러 처리

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
@@ -1,0 +1,45 @@
+package com.flexrate.flexrate_back.member.api;
+
+import com.flexrate.flexrate_back.member.application.MemberAdminService;
+import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
+import com.flexrate.flexrate_back.member.dto.MemberSearchResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/members")
+public class MemberAdminController {
+    private final MemberAdminService memberAdminService;
+
+    /**
+     * 관리자 권한으로 회원 목록 조회
+     * @param request 회원 검색 요청
+     * @param adminToken 관리자 인증 토큰
+     * @return 회원 검색 결과
+     * @since 2025.04.26
+     * @author 권민지
+     */
+    @Operation(summary = "관리자 권한으로 회원 목록 조회", description = "관리자가 회원 목록을 검색 조건에 따라 조회합니다.",
+            parameters = {@Parameter(name = "request", description = "회원 검색 요청(모든 인자 null 가능)", required = true),
+                          @Parameter(name = "X-Admin-Token", description = "관리자 인증 토큰", required = true)},
+            responses = {@ApiResponse(responseCode = "200", description = "회원 검색 결과 반환"),
+                         @ApiResponse(responseCode = "400", description = "관리자 인증 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A007\", \"message\": \"관리자 권한이 필요합니다.\"}"))),})
+    @GetMapping("/search")
+    public ResponseEntity<MemberSearchResponse> searchMembers(
+            @Valid MemberSearchRequest request,
+            @RequestHeader("X-Admin-Token") String adminToken
+    ) {
+        return ResponseEntity.ok(memberAdminService.searchMembers(request, adminToken));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthChecker.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthChecker.java
@@ -1,0 +1,5 @@
+package com.flexrate.flexrate_back.member.application;
+
+public interface AdminAuthChecker {
+    boolean isAdmin(String adminToken);
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthCheckerImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthCheckerImpl.java
@@ -1,0 +1,15 @@
+package com.flexrate.flexrate_back.member.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminAuthCheckerImpl implements AdminAuthChecker {
+
+    // 추후 변경
+    private static final String ADMIN_TOKEN = "adminToken";
+
+    @Override
+    public boolean isAdmin(String adminToken) {
+        return ADMIN_TOKEN.equals(adminToken);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -1,0 +1,65 @@
+package com.flexrate.flexrate_back.member.application;
+
+import com.flexrate.flexrate_back.common.dto.PaginationInfo;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.repository.MemberQueryRepository;
+import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
+import com.flexrate.flexrate_back.member.dto.MemberSearchResponse;
+import com.flexrate.flexrate_back.member.mapper.MemberMapper;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberAdminService {
+    private final MemberQueryRepository memberQueryRepository;
+    private final MemberMapper memberMapper;
+    private final AdminAuthChecker adminAuthChecker;
+
+    /**
+     * 관리자 권한으로 회원 목록 조회
+     * @param request 검색 조건
+     * @param adminToken 관리자 인증 토큰
+     * @return MemberSearchResponse 회원 목록, 페이징 정보
+     * @throws FlexrateException ErrorCode ADMIN_AUTH_REQUIRED 관리자 인증 필요
+     * @since 2025.04.26
+     * @author 권민지
+     */
+    public MemberSearchResponse searchMembers(@Valid MemberSearchRequest request, String adminToken) {
+        // A007 관리자 인증 체크
+        if (!adminAuthChecker.isAdmin(adminToken)) {
+            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
+        }
+
+        // 기본 정렬 createdAt 내림차순
+        Sort sort = request.sortBy() != null
+                ? Sort.by(request.sortBy().name()).ascending()
+                : Sort.by("createdAt").descending();
+
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                request.page() != null ? request.page() : 0,
+                request.size() != null ? request.size() : 10,
+                sort
+        );
+
+        var members = memberQueryRepository.searchMembers(request, pageable);
+
+        return MemberSearchResponse.builder()
+                .paginationInfo(new PaginationInfo(
+                        members.getNumber(),
+                        members.getSize(),
+                        members.getTotalPages(),
+                        members.getTotalElements()
+                ))
+                .members(members.getContent().stream()
+                        .map(memberMapper::toSummaryDto)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
@@ -1,11 +1,15 @@
 package com.flexrate.flexrate_back.member.domain;
 
 import com.flexrate.flexrate_back.member.enums.LoginMethod;
-import com.flexrate.flexrate_back.member.enums.UserStatus;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
 import com.flexrate.flexrate_back.loan.domain.LoanApplication;
 import com.flexrate.flexrate_back.notification.domain.Notification;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,16 +36,24 @@ public class Member {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = true, length = 20)
     private String phone;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Sex sex;
+
     private LocalDate birthDate;
+
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private UserStatus status;
+    private MemberStatus status;
 
     private LocalDateTime lastLoginAt;
 

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepository.java
@@ -1,0 +1,14 @@
+package com.flexrate.flexrate_back.member.domain.repository;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 회원 조회 쿼리
+ * - 읽기/검색 전용
+ */
+public interface MemberQueryRepository {
+    Page<Member> searchMembers(MemberSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.flexrate.flexrate_back.member.domain.repository;
+
+import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.QMember;
+import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
+import com.querydsl.core.types.dsl.Expressions;
+import lombok.RequiredArgsConstructor;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepositoryImpl implements MemberQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 회원 목록 조회
+     * @param request 검색 조건
+     * @param pageable 페이징 정보
+     * @return 회원 목록
+     * @since 2025.04.26
+     * @author 권민지
+     */
+    @Override
+    public Page<Member> searchMembers(MemberSearchRequest request, Pageable pageable) {
+        QMember member = QMember.member;
+
+        List<Member> members = queryFactory.selectFrom(member)
+                .where(
+                        member.name.containsIgnoreCase(request.name() != null ? request.name() : ""),
+                        member.email.containsIgnoreCase(request.email() != null ? request.email() : ""),
+                        request.sex() != null ? member.sex.eq(request.sex()) : null,
+                        request.birthDate() != null ? member.birthDate.eq(request.birthDate()) : null,
+                        request.memberStatus() != null ? member.status.eq(request.memberStatus()) : null,
+                        (request.startDate() != null ? member.createdAt.goe(request.startDate().atStartOfDay()) : null),
+                        (request.endDate() != null ? member.createdAt.loe(request.endDate().atTime(23, 59, 59)) : null),
+                        request.hasLoan() != null && request.hasLoan()
+                                ? member.loanApplication.status.ne(LoanApplicationStatus.APPROVED) : null,
+                        request.loanCount() != null ? member.loanApplication.count().eq(request.loanCount().longValue()) : null
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(pageable.getSort().stream()
+                        .map(order -> order.isAscending()
+                                ? Expressions.stringPath(order.getProperty()).asc()
+                                : Expressions.stringPath(order.getProperty()).desc())
+                        .toArray(com.querydsl.core.types.OrderSpecifier[]::new))
+                .fetch();
+
+        Long totalResult = queryFactory
+                .select(member.count())
+                .from(member)
+                .fetchFirst();
+
+        long total = totalResult == null ? 0 : totalResult;
+
+        return new PageImpl<>(members, pageable, total);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -42,7 +42,7 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
                         (request.endDate() != null ? member.createdAt.loe(request.endDate().atTime(23, 59, 59)) : null),
                         request.hasLoan() != null && request.hasLoan()
                                 ? member.loanApplication.status.ne(LoanApplicationStatus.APPROVED) : null,
-                        request.loanCount() != null ? member.loanApplication.count().eq(request.loanCount().longValue()) : null
+                        request.loanCount() != null ? member.loanApplication.getLoanTransactions().size().eq(request.loanCount().longValue()) : null
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
@@ -22,8 +22,8 @@ public record MemberSearchRequest(
         LocalDate endDate,
         Boolean hasLoan,
 
-        @Min(value = 0, message = "대출 횟수는 0 이상이어야 합니다.")
-        Integer loanCount,
+        @Min(value = 0, message = "거래 내역 횟수는 0 이상이어야 합니다.")
+        Integer loanTransactionCount,
 
         @Min(value = 0, message = "페이지는 0 이상이어야 합니다.")
         Integer page,

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
@@ -1,0 +1,40 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MemberSearchRequest(
+        @Size(max = 10, message = "이름은 최대 10자까지 입력할 수 있습니다.")
+        String name,
+
+        @Size(max = 50, message = "이메일은 최대 50자까지 입력할 수 있습니다.")
+        String email,
+
+        Sex sex,
+        LocalDate birthDate,
+        MemberStatus memberStatus,
+        LocalDate startDate,
+        LocalDate endDate,
+        Boolean hasLoan,
+
+        @Min(value = 0, message = "대출 횟수는 0 이상이어야 합니다.")
+        Integer loanCount,
+
+        @Min(value = 0, message = "페이지는 0 이상이어야 합니다.")
+        Integer page,
+
+        @Min(value = 1, message = "사이즈는 1 이상이어야 합니다.")
+        @Max(value = 200, message = "사이즈는 200 이하만 가능합니다.")
+        Integer size,
+
+        SortBy sortBy
+) {
+    public enum SortBy {
+        ID, NAME, CREATED_AT
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchResponse.java
@@ -1,0 +1,11 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.common.dto.PaginationInfo;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record MemberSearchResponse(
+        PaginationInfo paginationInfo,
+        List<MemberSummaryDto> members
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSummaryDto.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSummaryDto.java
@@ -18,5 +18,5 @@ public record MemberSummaryDto(
         LocalDateTime createdAt,
         LocalDateTime lastLoginAt,
         Boolean hasLoan,
-        Integer loanCount
+        Integer loanTransactionCount
 ) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSummaryDto.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSummaryDto.java
@@ -1,0 +1,22 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record MemberSummaryDto(
+        Long id,
+        String name,
+        String email,
+        Sex sex,
+        LocalDate birthDate,
+        MemberStatus memberStatus,
+        LocalDateTime createdAt,
+        LocalDateTime lastLoginAt,
+        Boolean hasLoan,
+        Integer loanCount
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/enums/MemberStatus.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/enums/MemberStatus.java
@@ -1,6 +1,6 @@
 package com.flexrate.flexrate_back.member.enums;
 
-public enum UserStatus {
+public enum MemberStatus {
     ACTIVE,
     WITHDRAWN,
     SUSPENDED

--- a/src/main/java/com/flexrate/flexrate_back/member/enums/Sex.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/enums/Sex.java
@@ -1,0 +1,6 @@
+package com.flexrate.flexrate_back.member.enums;
+
+public enum Sex {
+    MALE,
+    FEMALE
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/mapper/MemberMapper.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/mapper/MemberMapper.java
@@ -19,7 +19,7 @@ public class MemberMapper {
                 .lastLoginAt(member.getLastLoginAt())
                 // 현재 대출 서비스 이용 중 여부 (EXECUTED 상태인 경우)
                 .hasLoan(member.getLoanApplication() != null && member.getLoanApplication().getStatus() == LoanApplicationStatus.EXECUTED)
-                .loanCount(member.getLoanApplication() != null ? member.getLoanApplication().getLoanTransactions().size() : 0)
+                .loanTransactionCount(member.getLoanApplication() != null ? member.getLoanApplication().getLoanTransactions().size() : 0)
                 .build();
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/mapper/MemberMapper.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/mapper/MemberMapper.java
@@ -1,0 +1,25 @@
+package com.flexrate.flexrate_back.member.mapper;
+
+import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.dto.MemberSummaryDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberMapper {
+    public MemberSummaryDto toSummaryDto(Member member) {
+        return MemberSummaryDto.builder()
+                .id(member.getMemberId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .sex(member.getSex())
+                .birthDate(member.getBirthDate())
+                .memberStatus(member.getStatus())
+                .createdAt(member.getCreatedAt())
+                .lastLoginAt(member.getLastLoginAt())
+                // 현재 대출 서비스 이용 중 여부 (EXECUTED 상태인 경우)
+                .hasLoan(member.getLoanApplication() != null && member.getLoanApplication().getStatus() == LoanApplicationStatus.EXECUTED)
+                .loanCount(member.getLoanApplication() != null ? member.getLoanApplication().getLoanTransactions().size() : 0)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

#10

## 💜 작업 내용

- [x] 관리자 회원 검색 기능(DTO, QueryDSL, 페이징, 검증, 인증) 구현
- [x] DDD 구조 패키지 구조 및 역할 분리 적용
- [x] 공통 예외/유효성 처리 및 글로벌 예외 핸들러 추가
- [x] Swagger 문서화 및 REST API 명세 작성

## ✅ PR Point

- DDD 구조에 따라 `application`, `domain`, `dto`, `mapper` 등 계층별로 분리
- QueryDSL 기반 동적 검색, 페이징, 정렬을 지원하도록 쿼리 레이어 구현
- @Valid + javax.validation 입력값 검증 Controller/Service에서 일관되게 처리
- 관리자 인증 `AdminAuthChecker` 인터페이스로 추상화
- 글로벌 예외 처리 추가 (notion API 명세서 문서 참고)
- MemberMapper를 통해 Entity → DTO 변환 책임 분리

## 😡 Trouble Shooting

- QueryDSL에서 동적 조건 조합 시, null-safe 처리와 enum 변환에서 컴파일 에러가 발생하여, Optional/삼항 연산자 및 enum 타입의 명확한 분리로 해결
- 페이징, 정렬 파라미터가 누락될 경우 기본값 적용 로직 추가

## ☀ 스크린샷 / GIF / 화면
- 정상 응답
<img width="500" alt="스크린샷 2025-04-26 03 10 40" src="https://github.com/user-attachments/assets/ec6f6f94-c9ac-47cd-85a4-8a0197ae41a8" />

<hr/>

- 결과가 1개도 나오지 않을 경우

<img width="500" alt="스크린샷 2025-04-26 00 38 01" src="https://github.com/user-attachments/assets/7e10e3e0-a6f6-44cd-a880-20f2ec239b1f" />

<hr/>

- 유효성 검증 미통과한 경우

<img width="500" alt="스크린샷 2025-04-26 01 26 32" src="https://github.com/user-attachments/assets/2f905ec6-a89f-49b9-9dbe-433cd5051c8a" />

<hr/>

- 관리자 권한이 필요할 경우

<img width="500" alt="스크린샷 2025-04-26 01 32 14" src="https://github.com/user-attachments/assets/b0a7bed0-095f-4ce5-8be3-6f0db35c02ec" />

<hr/>


## 📚 산출물
[postapi 문서 업데이트](https://documenter.getpostman.com/view/33657317/2sB2izEYwi#b6097471-5b0e-4af3-bd65-8f9411c241d1)
[API 명세서 확인](https://www.notion.so/ryuseunghan/API-1dec3966a143801f8e15e570b66006cc)

## 🗣️ 전달사항
예제 코드 전달을 위해 테스트코드 없이 postman으로만 테스트 후 빠르게 PR합니다. 추후 테스트코드 추가 예정.