### PR TITLE
chore: ErrorCode HttpStatus 추가

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.flexrate.flexrate_back.common.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 /**
  * 에러 코드 및 메시지
@@ -11,35 +12,36 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     // 사용자 에러
-    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다"),
+    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
 
     // 대출
-    INVALID_APPLICATION("L001", "신청 정보가 올바르지 않습니다."),
-    LOAN_NOT_FOUND("L002", "대출 정보를 찾을 수 없습니다."),
-    APPROVAL_MISSING("L003", "승인 정보가 누락되었습니다."),
-    LOAN_ALREADY_APPROVED("L004", "이미 승인된 대출입니다."),
+    INVALID_APPLICATION("L001", "신청 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    LOAN_NOT_FOUND("L002", "대출 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    APPROVAL_MISSING("L003", "승인 정보가 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    LOAN_ALREADY_APPROVED("L004", "이미 승인된 대출입니다.", HttpStatus.BAD_REQUEST),
 
     // 인증/인가
-    AUTH_REQUIRED_FIELD_MISSING("A000", "필수 입력값이 누락되었습니다."),
-    EMAIL_ALREADY_REGISTERED("A001", "이미 가입된 이메일입니다."),
-    INVALID_CREDENTIALS("A002", "아이디 또는 비밀번호가 일치하지 않습니다."),
-    PASSKEY_AUTH_FAILED("A003", "패스키 인증에 실패했습니다."),
-    INVALID_REFRESH_TOKEN("A004", "유효하지 않은 리프레시 토큰입니다."),
-    INVALID_EMAIL_FORMAT("A005", "올바르지 않은 이메일 형식입니다."),
-    AUTHENTICATION_REQUIRED("A006", "인증이 필요합니다."),
-    ADMIN_AUTH_REQUIRED("A007", "관리자 권한이 필요합니다."),
+    AUTH_REQUIRED_FIELD_MISSING("A000", "필수 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_ALREADY_REGISTERED("A001", "이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
+    INVALID_CREDENTIALS("A002", "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    PASSKEY_AUTH_FAILED("A003", "패스키 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("A004", "유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_EMAIL_FORMAT("A005", "올바르지 않은 이메일 형식입니다.", HttpStatus.BAD_REQUEST),
+    AUTHENTICATION_REQUIRED("A006", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    ADMIN_AUTH_REQUIRED("A007", "관리자 권한이 필요합니다.", HttpStatus.FORBIDDEN),
 
     // 상품
-    PRODUCT_LOAD_ERROR("P001", "상품을 불러오는 중 오류가 발생했습니다."),
-    PRODUCT_NOT_FOUND("P002", "해당 상품을 찾을 수 없습니다."),
+    PRODUCT_LOAD_ERROR("P001", "상품을 불러오는 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
+    PRODUCT_NOT_FOUND("P002", "해당 상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 서버 오류
-    INTERNAL_SERVER_ERROR("S500", "서버 내부 오류"),
-    NOT_FOUND_STATIC_RESOURCE("S404", "요청한 정적 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR("S500", "서버 내부 오류", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOT_FOUND_STATIC_RESOURCE("S404", "요청한 정적 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 유효성
-    VALIDATION_ERROR("V001", "유효성 검사 오류");
+    VALIDATION_ERROR("V001", "유효성 검사 오류", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     INVALID_APPLICATION("L001", "신청 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     LOAN_NOT_FOUND("L002", "대출 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     APPROVAL_MISSING("L003", "승인 정보가 누락되었습니다.", HttpStatus.BAD_REQUEST),
-    LOAN_ALREADY_APPROVED("L004", "이미 승인된 대출입니다.", HttpStatus.BAD_REQUEST),
+    LOAN_ALREADY_APPROVED("L004", "이미 승인된 대출입니다.", HttpStatus.CONFLICT),
 
     // 인증/인가
     AUTH_REQUIRED_FIELD_MISSING("A000", "필수 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/GlobalExceptionHandler.java
@@ -61,17 +61,9 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(FlexrateException.class)
     public ResponseEntity<ErrorResponse> handleFlexrateException(FlexrateException ex, HttpServletRequest request) {
-        HttpStatus status = switch (ex.getCode()) {
-            case "A001" -> HttpStatus.CONFLICT;
-            case "A000", "A002", "A003", "A004", "M001", "M002" -> HttpStatus.UNAUTHORIZED;
-            case "L001", "L003", "L004", "P001" -> HttpStatus.BAD_REQUEST;
-            case "L002", "P002", "U001", "S404" -> HttpStatus.NOT_FOUND;
-            case "S500" -> HttpStatus.INTERNAL_SERVER_ERROR;
-            default -> HttpStatus.BAD_REQUEST;
-        };
-
-        String code = ex.getCode();
-        String message = ex.getMessage();
+        ErrorCode errorCode = ex.getErrorCode();
+        String code = errorCode.getCode();
+        String message = errorCode.getMessage();
         String path = request.getRequestURI();
 
         if (profileUtil.isProduction()) {
@@ -80,8 +72,8 @@ public class GlobalExceptionHandler {
             log.error("[{}] {} | path={} | detail={}", code, message, path, ex.getMessage());
         }
 
-        return ResponseEntity.status(status)
-                .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(new ErrorResponse(code, message));
     }
 
     /**


### PR DESCRIPTION
## 🔥 Related Issues

- close #14

## 💜 작업 내용

- [x] ErrorCode enum에 HttpStatus 필드 추가 및 모든 에러코드에 적절한 상태코드 지정
- [x] GlobalExceptionHandler에서 ErrorCode의 HttpStatus를 직접 사용하도록 리팩토링
- [x] handleFlexrateException 내 중복 상태 매핑 switch문 제거

## ✅ PR Point

- **변경 이유**  
  기존에는 ErrorCode와 HTTP 상태코드의 매핑이 분리되어 있어, 예외 처리 로직에서 불필요한 switch문이 필요했고, 새로운 에러 코드 추가 시 코드 일관성 및 유지보수가 어려웠습니다.
이를 개선하기 위해 ErrorCode에 HttpStatus 필드를 추가하여 각 에러 코드가 자신의 HTTP 상태코드를 스스로 가지도록 리팩토링했습니다.

- **변경 방식**  
  ErrorCode enum에 HttpStatus 필드를 추가하고, 모든 에러 코드에 맞는 상태코드 지정

- **리뷰어 집중 포인트**
  - 모든 ErrorCode에 HttpStatus가 올바르게 지정되어 있는지 확인 부탁드립니다.
  - 기존의 예외 처리 흐름이 변경되었으므로, 실제 API 응답의 status, code, message가 모두 기대대로 동작하는지 확인이 필요합니다. 테스트는 했지만, 혹시라도 작업 도중 의도대로 동작되지 않는 경우 말씀해주세요.

## 😡 Trouble Shooting

- **문제점:**  
  기존에 ErrorCode와 상태코드가 분리되어 있어,  
  새로운 에러코드 추가 시마다 GlobalExceptionHandler의 switch문도 함께 수정해야 했고, 실수로 매핑이 어긋나는 문제가 발생할 수 있었습니다.

- **해결 방법:**  
  ErrorCode에서 상태코드를 직접 관리하도록 구조를 변경함으로써 중복 코드를 제거하고, 매핑 실수를 방지할 수 있게 되었습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
- 에러 코드 정상 동작 확인 완료
<img width="490" alt="스크린샷 2025-04-28 10 39 16" src="https://github.com/user-attachments/assets/6574a99f-b6d5-42ed-8e83-8737e1cee221" />
