### PR TITLE
feature: 대출 신청 사전 정보 입력 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.flexrate.flexrate_back.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanPreApplicationController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanPreApplicationController.java
@@ -1,0 +1,56 @@
+package com.flexrate.flexrate_back.loan.api;
+
+import com.flexrate.flexrate_back.loan.application.LoanPreApplicationService;
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationRequest;
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/loans")
+@RequiredArgsConstructor
+public class LoanPreApplicationController {
+
+    private final LoanPreApplicationService preLoanApplicationService;
+
+    /**
+     * 대출 신청 사전 정보를 입력 받아 심사 결과를 반환하는 API
+     * @param request 대출 신청 사전 정보
+     * TODO: 멤버 토큰 및 예외 처리 관련 코드 추가
+     * @return 대출 심사 결과
+     * @since 2025.04.28
+     * @author 서채연
+     */
+    @Operation(
+            summary = "대출 신청 사전 정보 입력",
+            description = "고객의 기본 대출 신청 정보를 입력받아 대출 심사 결과를 반환합니다.",
+            parameters = {
+                    @Parameter(name = "request", description = "대출 신청 사전 정보", required = true),
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "대출 심사 결과 반환"),
+                    @ApiResponse(responseCode = "400", description = "요청 값 검증 실패",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(value = "{\"code\": \"V001\", \"message\": \"필수 입력값이 누락되었습니다.\"}"))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(value = "{\"code\": \"A006\", \"message\": \"인증이 필요합니다.\"}")))
+            }
+    )
+    @PostMapping("/pre-applications")
+    public LoanPreApplicationResponse preApplyLoan(
+            @RequestBody @Valid LoanPreApplicationRequest request
+    ) {
+        return preLoanApplicationService.preApply(request);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanPreApplicationService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanPreApplicationService.java
@@ -1,0 +1,55 @@
+package com.flexrate.flexrate_back.loan.application;
+
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationRequest;
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class LoanPreApplicationService {
+
+    private final RestTemplate restTemplate;
+
+    // 심사 서버 URL (추후 변경 예정)
+    private static final String SCREENING_SERVER_URL = "http://external-server/api";
+
+    /**
+     * 대출 신청 사전 정보를 외부 심사 서버로 전달 후, 심사 결과 반환
+     * @param request 대출 신청 기본 정보
+     * @return LoanPreApplicationResponse 대출 심사 결과
+     * @since 2025.04.28
+     * @author 서채연
+     */
+    public LoanPreApplicationResponse preApply(LoanPreApplicationRequest request) {
+        LoanPreApplicationResponse externalResponse = restTemplate.postForObject(
+                SCREENING_SERVER_URL,
+                request,
+                LoanPreApplicationResponse.class
+        );
+
+        if (externalResponse == null) {
+            throw new RuntimeException("심사 서버 응답이 없습니다.");
+        }
+
+        return LoanPreApplicationResponse.builder()
+                .name(externalResponse.getName())
+                .screeningDate(externalResponse.getScreeningDate())
+                .loanLimit(externalResponse.getLoanLimit())
+                .initialRate(externalResponse.getInitialRate())
+                .rateRangeFrom(externalResponse.getRateRangeFrom())
+                .rateRangeTo(externalResponse.getRateRangeTo())
+                .build();
+
+        // 테스트용 더미 데이터
+//        return LoanPreApplicationResponse.builder()
+//                .name("홍길동")
+//                .screeningDate("2025-04-28")
+//                .loanLimit(5000)
+//                .initialRate(4.9f)
+//                .rateRangeFrom(4.5f)
+//                .rateRangeTo(7.2f)
+//                .build();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanPreApplicationService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanPreApplicationService.java
@@ -30,7 +30,7 @@ public class LoanPreApplicationService {
         );
 
         if (externalResponse == null) {
-            throw new RuntimeException("심사 서버 응답이 없습니다.");
+            throw new IllegalStateException("심사 서버 응답이 없습니다.");
         }
 
         return LoanPreApplicationResponse.builder()

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationRequest.java
@@ -1,10 +1,11 @@
 package com.flexrate.flexrate_back.loan.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
@@ -12,33 +13,33 @@ import lombok.NoArgsConstructor;
 @Builder
 public class LoanPreApplicationRequest {
 
-    @NotNull
+    @NotBlank(message = "업종(businessType)은 필수 입력 항목입니다.")
     private String businessType;
 
-    @NotNull
+    @NotBlank(message = "고용형태(employmentType)은 필수 입력 항목입니다.")
     private String employmentType;
 
-    @NotNull
+    @NotBlank(message = "입사일자(hireDate)는 필수 입력 항목입니다.")
     private String hireDate;
 
-    @NotNull
+    @NotBlank(message = "학교명(schoolName)은 필수 입력 항목입니다.")
     private String schoolName;
 
-    @NotNull
+    @NotBlank(message = "학적 상태(educationStatus)는 필수 입력 항목입니다.")
     private String educationStatus;
 
-    @NotNull
+    @NotNull(message = "연소득(annualIncome)은 필수 입력 항목입니다.")
     private Integer annualIncome;
 
-    @NotNull
+    @NotBlank(message = "신용등급(creditGrade)은 필수 입력 항목입니다.")
     private String creditGrade;
 
-    @NotNull
+    @NotBlank(message = "주거 형태(residenceType)는 필수 입력 항목입니다.")
     private String residenceType;
 
-    @NotNull
+    @NotNull(message = "개인회생 여부(isBankrupt)는 필수 입력 항목입니다.")
     private Boolean isBankrupt;
 
-    @NotNull
+    @NotBlank(message = "대출 목적(loanPurpose)은 필수 입력 항목입니다.")
     private String loanPurpose;
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationRequest.java
@@ -1,0 +1,44 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoanPreApplicationRequest {
+
+    @NotNull
+    private String businessType;
+
+    @NotNull
+    private String employmentType;
+
+    @NotNull
+    private String hireDate;
+
+    @NotNull
+    private String schoolName;
+
+    @NotNull
+    private String educationStatus;
+
+    @NotNull
+    private Integer annualIncome;
+
+    @NotNull
+    private String creditGrade;
+
+    @NotNull
+    private String residenceType;
+
+    @NotNull
+    private Boolean isBankrupt;
+
+    @NotNull
+    private String loanPurpose;
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationResponse.java
@@ -1,0 +1,17 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LoanPreApplicationResponse {
+    private String name;
+    private String screeningDate;
+    private Integer loanLimit;
+    private Float initialRate;
+    private Float rateRangeFrom;
+    private Float rateRangeTo;
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/EducationStatus.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/EducationStatus.java
@@ -1,0 +1,9 @@
+package com.flexrate.flexrate_back.loan.enums;
+
+public enum EducationStatus {
+    ENROLLED,
+    GRADUATED,
+    LEAVE,
+    DROPPED,
+    ETC
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/EmploymentType.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/EmploymentType.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.loan.enums;
+
+public enum EmploymentType {
+    FULL_TIME,
+    CONTRACT,
+    PART_TIME,
+    SELF_EMPLOYED,
+    UNEMPLOYED,
+    ETC
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanPurpose.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanPurpose.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.loan.enums;
+
+public enum LoanPurpose {
+    LIVING,
+    BUSINESS,
+    CAR,
+    EDUCATION,
+    HOUSE,
+    ETC
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/ResidenceType.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/ResidenceType.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.loan.enums;
+
+public enum ResidenceType {
+    OWN,
+    JEONSE,
+    MONTHLY
+}

--- a/src/test/java/com/flexrate/flexrate_back/loan/api/LoanPreApplicationControllerTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/loan/api/LoanPreApplicationControllerTest.java
@@ -1,0 +1,71 @@
+package com.flexrate.flexrate_back.loan.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LoanPreApplicationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("대출 사전 신청 - 정상 요청")
+    void preApplyLoan_success() throws Exception {
+        LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
+                .businessType("IT")
+                .employmentType("FULL_TIME")
+                .hireDate("2022-01")
+                .schoolName("서울대학교")
+                .educationStatus("GRADUATED")
+                .annualIncome(3500)
+                .creditGrade("2")
+                .residenceType("OWNED")
+                .isBankrupt(false)
+                .loanPurpose("BUSINESS")
+                .build();
+
+        mockMvc.perform(post("/api/loans/pre-applications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").exists())
+                .andExpect(jsonPath("$.loanLimit").exists());
+    }
+
+    @Test
+    @DisplayName("대출 사전 신청 - 필수값 누락 시 400 반환")
+    void preApplyLoan_validationFail() throws Exception {
+        LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
+                .employmentType("FULL_TIME")
+                .hireDate("2022-01")
+                .schoolName("서울대학교")
+                .educationStatus("GRADUATED")
+                .annualIncome(3500)
+                .creditGrade("2")
+                .residenceType("OWNED")
+                .isBankrupt(false)
+                .loanPurpose("BUSINESS")
+                .build();
+
+        mockMvc.perform(post("/api/loans/pre-applications")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/flexrate/flexrate_back/loan/api/LoanPreApplicationControllerTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/loan/api/LoanPreApplicationControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -26,7 +27,7 @@ class LoanPreApplicationControllerTest {
 
     @Test
     @DisplayName("대출 사전 신청 - 정상 요청")
-    void preApplyLoan_success() throws Exception {
+    void preApplyLoanSuccess() throws Exception {
         LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
                 .businessType("IT")
                 .employmentType("FULL_TIME")
@@ -50,7 +51,7 @@ class LoanPreApplicationControllerTest {
 
     @Test
     @DisplayName("대출 사전 신청 - 필수값 누락 시 400 반환")
-    void preApplyLoan_validationFail() throws Exception {
+    void preApplyLoanValidationFail() throws Exception {
         LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
                 .employmentType("FULL_TIME")
                 .hireDate("2022-01")
@@ -66,6 +67,7 @@ class LoanPreApplicationControllerTest {
         mockMvc.perform(post("/api/loans/pre-applications")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andReturn();
     }
 }

--- a/src/test/java/com/flexrate/flexrate_back/loan/application/LoanPreApplicationServiceTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/loan/application/LoanPreApplicationServiceTest.java
@@ -1,0 +1,61 @@
+package com.flexrate.flexrate_back.loan.application;
+
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationRequest;
+import com.flexrate.flexrate_back.loan.dto.LoanPreApplicationResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class LoanPreApplicationServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private LoanPreApplicationService loanPreApplicationService;
+
+    public LoanPreApplicationServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("LoanPreApplicationService - 정상 응답 테스트")
+    void preApplySuccess() {
+        LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
+                .businessType("IT")
+                .employmentType("FULL_TIME")
+                .hireDate("2022-01")
+                .schoolName("서울대학교")
+                .educationStatus("GRADUATED")
+                .annualIncome(3500)
+                .creditGrade("2")
+                .residenceType("OWNED")
+                .isBankrupt(false)
+                .loanPurpose("BUSINESS")
+                .build();
+
+        LoanPreApplicationResponse mockResponse = LoanPreApplicationResponse.builder()
+                .name("홍길동")
+                .screeningDate("2025-04-28")
+                .loanLimit(5000)
+                .initialRate(4.9f)
+                .rateRangeFrom(4.5f)
+                .rateRangeTo(7.2f)
+                .build();
+
+        when(restTemplate.postForObject(any(String.class), any(), any()))
+                .thenReturn(mockResponse);
+
+        LoanPreApplicationResponse result = loanPreApplicationService.preApply(request);
+
+        assertThat(result.getName()).isEqualTo("홍길동");
+        assertThat(result.getLoanLimit()).isEqualTo(5000);
+    }
+}

--- a/src/test/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationRequestTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/loan/dto/LoanPreApplicationRequestTest.java
@@ -1,0 +1,64 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoanPreApplicationRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("LoanPreApplicationRequest - 정상 데이터로 검증 성공")
+    void validateSuccess() {
+        LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
+                .businessType("IT")
+                .employmentType("FULL_TIME")
+                .hireDate("2022-01")
+                .schoolName("서울대학교")
+                .educationStatus("GRADUATED")
+                .annualIncome(3500)
+                .creditGrade("2")
+                .residenceType("OWNED")
+                .isBankrupt(false)
+                .loanPurpose("BUSINESS")
+                .build();
+
+        Set<ConstraintViolation<LoanPreApplicationRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("LoanPreApplicationRequest - businessType이 빈 문자열이면 검증 실패")
+    void validateFailBlankBusinessType() {
+        LoanPreApplicationRequest request = LoanPreApplicationRequest.builder()
+                .businessType("")
+                .employmentType("FULL_TIME")
+                .hireDate("2022-01")
+                .schoolName("서울대학교")
+                .educationStatus("GRADUATED")
+                .annualIncome(3500)
+                .creditGrade("2")
+                .residenceType("OWNED")
+                .isBankrupt(false)
+                .loanPurpose("BUSINESS")
+                .build();
+
+        Set<ConstraintViolation<LoanPreApplicationRequest>> violations = validator.validate(request);
+        assertThat(violations).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #12 

## 💜 작업 내용

- [x] 대출 신청 사전 정보 DTO(Request, Response) 설계
- [x] RestTemplate 설정
- [x] preLoanApplicationService
- [x] preLoanApplicationController
- [x] 관련 ENUM 작성

## ✅ PR Point

- 멤버 토큰 인증 및 예외 처리 관련한 코드는 제외된 상태입니다. (추후 추가 예정)
- 저번에 논의 나왔던 서비스에서 외부 심사 서버와의 요청 및 응답 dto까지 총 4개 작성해야하는 거 아닌가 하는 이야기가 나왔었는데 일단 dto 동일한 형태로 요청/응답이 오갈 것이라 생각하고 dto는 총 2개 작성했습니다.
- 외부 서버와의 http 통신을 위한 RestTemplate 설정 작업을 진행했습니다.
- Service에서 현재 외부 서버가 없다 보니 실제 응답을 해줄 수 없는 상황이라 테스트를 위해 주석으로 더미 데이터 반환 코드를 넣어두었습니다.
- dto, controller, service 총 3가지의 테스트 코드를 작성하였습니다.(이렇게 작성하는게 맞는지 궁금하네요.. 적극 리뷰 환영입니다.)

## ☀ 스크린샷 / GIF / 화면 녹화
테스트코드 실행 화면
![Apr-28-2025 14-48-46](https://github.com/user-attachments/assets/40fd7721-a383-4719-8ba1-841258de428e)

