### PR TITLE
feature: 관리자용 특정 사용자 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
@@ -1,15 +1,11 @@
 package com.flexrate.flexrate_back.member.api;
 
 import com.flexrate.flexrate_back.member.application.MemberAdminService;
-import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
-import com.flexrate.flexrate_back.member.dto.MemberSearchResponse;
+import com.flexrate.flexrate_back.member.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -41,5 +37,36 @@ public class MemberAdminController {
             @RequestHeader("X-Admin-Token") String adminToken
     ) {
         return ResponseEntity.ok(memberAdminService.searchMembers(request, adminToken));
+    }
+
+    /**
+     * 관리자 권한으로 회원 정보 수정
+     * @param request 회원 정보 수정 요청
+     * @param adminToken 관리자 인증 토큰
+     * @return 회원 정보 수정 결과
+     * @since 2025.04.26
+     * @author 허연규
+     */
+    @Operation(summary = "관리자 권한으로 회원 정보 수정", description = "관리자가 회원 id를 통해 특정 회원의 정보를 수정합니다.",
+    parameters = {
+            @Parameter(name = "memberId", description = "수정할 memberId", required = true),
+            @Parameter(name = "X-Admin-Token", description = "관리자 인증 토큰", required = true)},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원 정보 수정 결과 반환"),
+                    @ApiResponse(responseCode = "400", description = "관리자 인증 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A007\", \"message\": \"관리자 권한이 필요합니다.\"}"))),
+                    @ApiResponse(responseCode = "400", description = "사용자가 존재하지 않음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"U001\", \"message\": \"사용자를 찾을 수 없습니다.\"}"))),
+                    @ApiResponse(responseCode = "400", description = "필수 입력값 누락", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A000\", \"message\": \"필수 입력값이 누락되었습니다.\"}"))),
+                    @ApiResponse(responseCode = "400", description = "유효성 검사 오류", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"V001\", \"message\": \"유효성 검사 오류\"}"))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"S500\", \"message\": \"서버 내부 오류\"}"))),
+            })
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<PatchMemberResponse> patchMember(
+            @PathVariable Long memberId,
+            @Valid @RequestBody PatchMemberRequest request,
+            @RequestHeader("X-Admin-Token") String adminToken
+    ) {
+        return ResponseEntity.ok(
+                memberAdminService.patchMember(memberId, request, adminToken)
+        );
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -3,9 +3,10 @@ package com.flexrate.flexrate_back.member.application;
 import com.flexrate.flexrate_back.common.dto.PaginationInfo;
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import com.flexrate.flexrate_back.member.domain.repository.MemberQueryRepository;
-import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
-import com.flexrate.flexrate_back.member.dto.MemberSearchResponse;
+import com.flexrate.flexrate_back.member.dto.*;
 import com.flexrate.flexrate_back.member.mapper.MemberMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberAdminService {
+    private final MemberRepository memberRepository;
     private final MemberQueryRepository memberQueryRepository;
     private final MemberMapper memberMapper;
     private final AdminAuthChecker adminAuthChecker;
@@ -60,6 +64,55 @@ public class MemberAdminService {
                 .members(members.getContent().stream()
                         .map(memberMapper::toSummaryDto)
                         .toList())
+                .build();
+    }
+
+    /**
+     * 관리자 권한으로 회원 정보 수정
+     * @param request 수정할 회원 정보
+     * @param adminToken 관리자 인증 토큰
+     * @return MemberSearchResponse 수정된 회원 정보
+     * @throws FlexrateException ErrorCode ADMIN_AUTH_REQUIRED 관리자 인증 필요, USER_NOT_FOUND 사용자를 찾지 못함,
+     * AUTH_REQUIRED_FIELD_MISSING 필수 입력값 누락
+     * @since 2025.04.26
+     * @author 허연규
+     */
+    public PatchMemberResponse patchMember(Long memberId, @Valid PatchMemberRequest request, String adminToken) {
+        // A007 관리자 인증 체크
+        if (!adminAuthChecker.isAdmin(adminToken)) {
+            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
+        }
+
+        // U001 유저 존재 여부 체크
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        // A000 필수 입력값 누락 체크
+        if (request.name() == null && request.sex() == null
+                && request.birthDate() == null && request.memberStatus() == null) {
+            throw new FlexrateException(ErrorCode.AUTH_REQUIRED_FIELD_MISSING);
+        }
+
+        if (request.name() != null) {
+            member.updateName(request.name());
+        }
+        if (request.sex() != null) {
+            member.updateSex(request.sex());
+        }
+        if (request.birthDate() != null) {
+            member.updateBirthDate(request.birthDate());
+        }
+        if (request.memberStatus() != null) {
+            member.updateMemberStatus(request.memberStatus());
+        }
+
+        return PatchMemberResponse.builder()
+                .memberId(member.getMemberId())
+                .name(member.getName())
+                .sex(member.getSex())
+                .birthDate(member.getBirthDate())
+                .memberStatus(member.getStatus())
+                .updatedAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -77,6 +77,7 @@ public class MemberAdminService {
      * @since 2025.04.26
      * @author 허연규
      */
+    @Transactional
     public PatchMemberResponse patchMember(Long memberId, @Valid PatchMemberRequest request, String adminToken) {
         // A007 관리자 인증 체크
         if (!adminAuthChecker.isAdmin(adminToken)) {

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
@@ -65,4 +65,20 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Notification> notifications;
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateSex(Sex sex) {
+        this.sex = sex;
+    }
+
+    public void updateBirthDate(LocalDate localDate) {
+        this.birthDate = localDate;
+    }
+
+    public void updateMemberStatus(MemberStatus memberStatus) {
+        this.status = memberStatus;
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.flexrate.flexrate_back.member.domain.repository;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // 기본 CRUD 메서드 제공
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/PatchMemberRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/PatchMemberRequest.java
@@ -1,0 +1,19 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record PatchMemberRequest(
+        @Size(max = 20, message = "이름은 최대 20자까지 입력할 수 있습니다.")
+        String name,
+
+        Sex sex,
+        LocalDate birthDate,
+        MemberStatus memberStatus
+) {
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/PatchMemberResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/PatchMemberResponse.java
@@ -1,0 +1,24 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PatchMemberResponse {
+    private Long memberId;
+    private String name;
+    private Sex sex;
+    private LocalDate birthDate;
+    private MemberStatus memberStatus;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime updatedAt;
+}

--- a/src/test/java/com/flexrate/flexrate_back/member/application/MemberAdminServiceTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/member/application/MemberAdminServiceTest.java
@@ -1,0 +1,142 @@
+package com.flexrate.flexrate_back.member.application;
+
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.member.dto.PatchMemberRequest;
+import com.flexrate.flexrate_back.member.dto.PatchMemberResponse;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class MemberAdminServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AdminAuthChecker adminAuthChecker;
+
+    @InjectMocks
+    private MemberAdminService memberAdminService;
+
+    public MemberAdminServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+
+    /**
+     * 관리자 권한으로 회원 정보 수정 테스트
+     * @since 2025.04.28
+     * 허연규
+     * */
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .memberId(1L)
+                .name("김영희")
+                .birthDate(LocalDate.of(1980, 1, 1))
+                .sex(Sex.FEMALE)
+                .status(MemberStatus.SUSPENDED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("MemberAdminService - 회원 수정 정상 응답 테스트")
+    void patchMemberSuccess() {
+        // given
+        PatchMemberRequest request = PatchMemberRequest.builder()
+                .name("홍길동")
+                .birthDate(LocalDate.of(1990, 10, 10))
+                .sex(Sex.MALE)
+                .memberStatus(MemberStatus.ACTIVE)
+                .build();
+
+        when(adminAuthChecker.isAdmin(any())).thenReturn(true);
+        when(memberRepository.findById(any(Long.class))).thenReturn(Optional.of(member));
+
+        // when
+        PatchMemberResponse response = memberAdminService.patchMember(1L, request, "adminToken");
+
+        // then
+        assertThat(response.getName()).isEqualTo("홍길동");
+        assertThat(response.getBirthDate()).isEqualTo(LocalDate.of(1990, 10, 10));
+        assertThat(response.getSex()).isEqualTo(Sex.MALE);
+        assertThat(response.getMemberStatus()).isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("MemberAdminService - 관리자 인증 실패")
+    public void patchMemberFail_AdminTokenNotFound() {
+        // given
+        PatchMemberRequest request = PatchMemberRequest.builder()
+                .name("홍길동")
+                .birthDate(LocalDate.of(1990, 10, 10))
+                .sex(Sex.MALE)
+                .memberStatus(MemberStatus.ACTIVE)
+                .build();
+
+        when(adminAuthChecker.isAdmin(any())).thenReturn(false);
+
+        // when & then
+        FlexrateException exception = assertThrows(FlexrateException.class, () -> {
+            memberAdminService.patchMember(1L, request, "NoToken");
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ADMIN_AUTH_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("MemberAdminService - 유저가 존재하지 않음")
+    public void patchMemberFail_UserNotFound() {
+        // given
+        PatchMemberRequest request = PatchMemberRequest.builder()
+                .name("홍길동")
+                .birthDate(LocalDate.of(1990, 10, 10))
+                .sex(Sex.MALE)
+                .memberStatus(MemberStatus.ACTIVE)
+                .build();
+
+        when(adminAuthChecker.isAdmin(any())).thenReturn(true);
+
+        // when & then
+        FlexrateException exception = assertThrows(FlexrateException.class, () -> {
+            memberAdminService.patchMember(2L, request, "adminToken");
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("MemberAdminService - 필수 입력값 누락")
+    public void patchMemberFail_NullMember() {
+        // given
+        PatchMemberRequest request = PatchMemberRequest.builder().build();
+
+        when(adminAuthChecker.isAdmin(any())).thenReturn(true);
+        when(memberRepository.findById(any(Long.class))).thenReturn(Optional.of(member));
+
+        // when & then
+        FlexrateException exception = assertThrows(FlexrateException.class, () -> {
+            memberAdminService.patchMember(1L, request, "adminToken");
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_REQUIRED_FIELD_MISSING);
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #13 

## 💜 작업 내용

- [x] DTO 설계
- [x] MemberAdminService에 코드 추가
- [x] MemberAdminController에 코드 추가
- [x] MemberRepository 생성
- [x] Member에 메서드 추가

## ✅ PR Point

- 특정 사용자 검색을 위해 MemberRepository 생성
- MemberAdminService와 Controller에 관련 코드 추가
- Member에 사용자 정보 수정을 위해서 @Setter 사용하는 대신 update 메서드 추가(QueryDSL 사용도 고려하였으나 프로젝트에 더 적절한 방식은 엔티티 update 메서드라고 생각했습니다.)
- service 테스트 코드까지 작성(나머지 테스트 코드는 추후에 추가하겠습니다.)

## 😡 Trouble Shooting

- postman 및 swagger로 테스트 해볼 때 서버 오류 발생. 사용자 데이터 넣는 걸 잊은 거였으므로 application.yml에서 ddl-auto: none->create 바꾸고 실행하여 데이터베이스에 table 생성. 이후 insert로 사용자 데이터를 생성하여 진행..^^

## ☀ 스크린샷 / GIF / 화면 녹화

사용자(memberId=1) 값 수정
![image](https://github.com/user-attachments/assets/10985a0d-cf1f-4807-81a2-ffae886d971f)

관리자 인증 실패
![image](https://github.com/user-attachments/assets/0f24acf2-9169-4692-83de-02e8d228e4c5)

사용자가 존재하지 않음
![image](https://github.com/user-attachments/assets/a90d74f5-0c26-444f-ab28-9d3c1680c693)

필수 입력값 누락
![image](https://github.com/user-attachments/assets/06714947-2ac2-44c7-aff5-5af05540d9a4)
