### PR TITLE
feat: 사용자 입금 내역 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/UserFinancialData.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/UserFinancialData.java
@@ -1,6 +1,6 @@
-package com.flexrate.flexrate_back.finantialdata.domain;
+package com.flexrate.flexrate_back.financialdata.domain;
 
-import com.flexrate.flexrate_back.finantialdata.enums.UserFinancialDataType;
+import com.flexrate.flexrate_back.financialdata.enums.UserFinancialDataType;
 import com.flexrate.flexrate_back.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/enums/UserFinancialDataType.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/enums/UserFinancialDataType.java
@@ -1,4 +1,4 @@
-package com.flexrate.flexrate_back.finantialdata.enums;
+package com.flexrate.flexrate_back.financialdata.enums;
 
 public enum UserFinancialDataType {
     INCOME,

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -1,0 +1,52 @@
+package com.flexrate.flexrate_back.loan.api;
+
+import com.flexrate.flexrate_back.loan.application.LoanAdminService;
+import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+
+@RestController
+@RequestMapping("/api/admin/loans")
+@RequiredArgsConstructor
+public class LoanAdminController {
+    private final LoanAdminService loanAdminService;
+
+    /**
+     * 대출 거래 내역 목록 조회
+     * @param memberId 사용자 ID
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param sortBy 정렬 기준
+     * @return 대출 거래 내역 목록
+     * @since 2025.04.26
+     * @author 권민지
+     */
+    @Operation(summary = "대출 거래 내역 목록 조회", description = "관리자가 특정 사용자의 대출 거래 내역을 조회합니다.",
+            parameters = {
+                @Parameter(name = "memberId", description = "사용자 ID", required = true),
+                @Parameter(name = "page", description = "페이지 번호", required = false),
+                @Parameter(name = "size", description = "페이지 크기", required = false),
+                @Parameter(name = "sortBy", description = "정렬 기준", required = false)
+            },
+            responses = {
+                @ApiResponse(responseCode = "200", description = "대출 거래 내역 목록 조회 성공"),
+                @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"U001\", \"message\": \"사용자를 찾을 수 없습니다.\"}")))
+            })
+    @GetMapping("/members/{memberId}/transactions")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<TransactionHistoryResponse> getTransactionHistory(
+            @PathVariable("memberId") Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "date") String sortBy
+    ) {
+        return ResponseEntity.ok(loanAdminService.getTransactionHistory(memberId, page, size, sortBy));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -1,0 +1,72 @@
+package com.flexrate.flexrate_back.loan.application;
+
+import com.flexrate.flexrate_back.common.dto.PaginationInfo;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.loan.application.repository.LoanTransactionQueryRepository;
+import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
+import com.flexrate.flexrate_back.loan.mapper.LoanTransactionMapper;
+import com.flexrate.flexrate_back.member.application.AdminAuthChecker;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoanAdminService {
+    private final LoanTransactionQueryRepository loanTransactionQueryRepository;
+    private final LoanTransactionMapper loanTransactionMapper;
+    private final MemberRepository memberRepository;
+    private final AdminAuthChecker adminAuthChecker;
+
+    /**
+     * 대출 거래 내역 목록 조회
+     * @param memberId 사용자 ID
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param sortBy 정렬 기준
+     * @return 입금 내역 상세 정보(페이지네이션)
+     * @since 2025.04.29
+     * @author 권민지
+     */
+    public TransactionHistoryResponse getTransactionHistory(
+            Long memberId,
+            int page,
+            int size,
+            String sortBy
+    ) {
+        // A007 관리자 인증 체크
+//        if (!adminAuthChecker.isAdmin(adminToken)) {
+//            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
+//        }
+
+        // U001 유저 존재 여부 체크
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+
+        // 기본 정렬 occurredAt 내림차순
+        Sort sort = sortBy != null
+                ? Sort.by(sortBy).ascending()
+                : Sort.by("occurredAt").descending();
+
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size, sort);
+
+        var transactionHistory = loanTransactionQueryRepository.findByMemberId(memberId, pageable);
+
+        return TransactionHistoryResponse.builder()
+                .paginationInfo(new PaginationInfo(
+                        transactionHistory.getNumber(),
+                        transactionHistory.getSize(),
+                        transactionHistory.getTotalPages(),
+                        transactionHistory.getTotalElements()
+                ))
+                .transactionHistories(transactionHistory.getContent().stream()
+                        .map(loanTransactionMapper::toSummaryDto)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -50,7 +50,9 @@ public class LoanAdminService {
 
         // 기본 정렬 occurredAt 내림차순
         Sort sort = sortBy != null
-                ? Sort.by(sortBy).ascending()
+                ? (sortBy.equals("occurredAt") 
+                    ? Sort.by(sortBy).descending() 
+                    : Sort.by(sortBy).ascending())
                 : Sort.by("occurredAt").descending();
 
         Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size, sort);

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanTransactionQueryRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanTransactionQueryRepository.java
@@ -1,0 +1,9 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanTransaction;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LoanTransactionQueryRepository {
+    Page<LoanTransaction> findByMemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanTransactionQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanTransactionQueryRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanTransaction;
+import com.flexrate.flexrate_back.loan.domain.QLoanTransaction;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class LoanTransactionQueryRepositoryImpl implements LoanTransactionQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 대출 거래 내역 목록 조회
+     * @param memberId 사용자 ID
+     * @param pageable 페이징 정보
+     * @return 대출 거래 내역 목록
+     * @since 2025.04.29
+     * @author 권민지
+     */
+    @Override
+    public Page<LoanTransaction> findByMemberId(Long memberId, Pageable pageable) {
+        QLoanTransaction loanTransaction = QLoanTransaction.loanTransaction;
+
+        List<LoanTransaction> content = queryFactory.selectFrom(loanTransaction)
+                .where(loanTransaction.member.memberId.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                // createdAt으로 내림차순
+                .orderBy(loanTransaction.occurredAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(loanTransaction.count())
+                .from(loanTransaction)
+                .where(loanTransaction.member.memberId.eq(memberId))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/TransactionHistoryResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/TransactionHistoryResponse.java
@@ -1,0 +1,12 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import com.flexrate.flexrate_back.common.dto.PaginationInfo;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record TransactionHistoryResponse (
+        PaginationInfo paginationInfo,
+        List<TransactionHistorySummaryDto> transactionHistories
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/TransactionHistorySummaryDto.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/TransactionHistorySummaryDto.java
@@ -1,0 +1,18 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import com.flexrate.flexrate_back.loan.enums.TransactionStatus;
+import com.flexrate.flexrate_back.loan.enums.TransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TransactionHistorySummaryDto (
+        Long transactionId,
+        Long applicationId,
+        Long memberId,
+        TransactionType type,
+        double amount,
+        LocalDateTime occurredAt,
+        TransactionStatus status
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanTransactionMapper.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanTransactionMapper.java
@@ -1,0 +1,20 @@
+package com.flexrate.flexrate_back.loan.mapper;
+
+import com.flexrate.flexrate_back.loan.domain.LoanTransaction;
+import com.flexrate.flexrate_back.loan.dto.TransactionHistorySummaryDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoanTransactionMapper {
+    public TransactionHistorySummaryDto toSummaryDto(LoanTransaction loanTransaction) {
+        return TransactionHistorySummaryDto.builder()
+                .transactionId(loanTransaction.getTransactionId())
+                .applicationId(loanTransaction.getApplication().getApplicationId())
+                .memberId(loanTransaction.getMember().getMemberId())
+                .type(loanTransaction.getType())
+                .amount(loanTransaction.getAmount())
+                .occurredAt(loanTransaction.getOccurredAt())
+                .status(loanTransaction.getStatus())
+                .build();
+    }
+}

--- a/src/test/java/com/flexrate/flexrate_back/loan/api/LoanAdminControllerTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/loan/api/LoanAdminControllerTest.java
@@ -1,0 +1,121 @@
+package com.flexrate.flexrate_back.loan.api;
+
+import com.flexrate.flexrate_back.loan.application.LoanAdminService;
+import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
+import com.flexrate.flexrate_back.common.dto.PaginationInfo;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class LoanAdminControllerTest {
+
+    @Mock
+    private LoanAdminService loanAdminService;
+
+    @InjectMocks
+    private LoanAdminController loanAdminController;
+
+    @Test
+    @DisplayName("정상적으로 대출 거래 내역 목록을 조회한다")
+    void getTransactionHistory_success() {
+        // given
+        long memberId = 1L;
+        TransactionHistoryResponse response = TransactionHistoryResponse.builder()
+                .paginationInfo(new PaginationInfo(0, 10, 1, 1))
+                .transactionHistories(Collections.emptyList())
+                .build();
+
+        given(loanAdminService.getTransactionHistory(eq(memberId), anyInt(), anyInt(), anyString()))
+                .willReturn(response);
+
+        // when
+        ResponseEntity<TransactionHistoryResponse> result = loanAdminController.getTransactionHistory(
+                memberId, 0, 10, "date"
+        );
+
+        // then
+        assertEquals(200, result.getStatusCodeValue());
+        assertNotNull(result.getBody());
+        assertEquals(0, result.getBody().paginationInfo().currentPage());
+        assertTrue(result.getBody().transactionHistories().isEmpty());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원일 경우 404를 반환한다")
+    void getTransactionHistory_userNotFound() {
+        // given
+        long memberId = 999L;
+        given(loanAdminService.getTransactionHistory(eq(memberId), anyInt(), anyInt(), anyString()))
+                .willThrow(new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        // when
+        FlexrateException ex = assertThrows(
+                FlexrateException.class,
+                () -> loanAdminController.getTransactionHistory(memberId, 0, 10, "date")
+        );
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("거래 내역이 없는 경우 빈 리스트를 반환한다")
+    void getTransactionHistory_noTransactions() {
+        // given
+        long memberId = 2L;
+        TransactionHistoryResponse response = TransactionHistoryResponse.builder()
+                .paginationInfo(new PaginationInfo(0, 10, 1, 0))
+                .transactionHistories(Collections.emptyList())
+                .build();
+
+        given(loanAdminService.getTransactionHistory(eq(memberId), anyInt(), anyInt(), anyString()))
+                .willReturn(response);
+
+        // when
+        ResponseEntity<TransactionHistoryResponse> result = loanAdminController.getTransactionHistory(
+                memberId, 0, 10, "date"
+        );
+
+        // then
+        assertEquals(200, result.getStatusCodeValue());
+        assertTrue(result.getBody().transactionHistories().isEmpty());
+    }
+
+    @Test
+    @DisplayName("페이징/정렬 파라미터가 정상적으로 동작한다")
+    void getTransactionHistory_pagingAndSorting() {
+        // given
+        long memberId = 1L;
+        TransactionHistoryResponse response = TransactionHistoryResponse.builder()
+                .paginationInfo(new PaginationInfo(1, 5, 2, 10))
+                .transactionHistories(Collections.emptyList())
+                .build();
+
+        given(loanAdminService.getTransactionHistory(eq(memberId), eq(1), eq(5), eq("occurredAt")))
+                .willReturn(response);
+
+        // when
+        ResponseEntity<TransactionHistoryResponse> result = loanAdminController.getTransactionHistory(
+                memberId, 1, 5, "occurredAt"
+        );
+
+        // then
+        assertEquals(200, result.getStatusCodeValue());
+        assertEquals(1, result.getBody().paginationInfo().currentPage());
+        assertEquals(5, result.getBody().paginationInfo().pageSize());
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #20 

## 💜 작업 내용

- [x] 관리자 대출 거래 내역 조회 API(Controller, Service, QueryRepository, DTO, Mapper) 구현
- [x] 도메인/enum 패키지 오타(finantial → financial) 수정 및 import 경로 정리
- [x] 대출 거래 내역 단위 테스트(JUnit5 + Mockito 기반) 추가
- [x] 거래 내역 응답(Response) 스키마 표준화 및 페이징 정보 구조화

## ✅ PR Point

- 기존 오타 패키지명(finantial → financial)을 개선했으니, 기존 코드와의 호환성에 주의해 주세요.
- Querydsl 기반 QueryRepository 구현
  - 거래 내역은 `occurredAt` 내림차순 정렬 기본 적용
  - 추후 정렬 파라미터 확장 가능
- 응답 데이터 구조 및 예시
  - 노션 참고: [API 명세서](https://www.notion.so/ryuseunghan/1e3c3966a143809990b3c5237591bfad)
  - postman 문서화 갱신: [postman api 문서](https://documenter.getpostman.com/view/33657317/2sB2izEYwi)
  

## 😡 Trouble Shooting

- Spring Boot 3.3+에서 @MockBean 사용시 Deprecation 경고
  → JUnit5 + Mockito 조합으로 순수 단위 테스트 구조로 리팩토링

## ☀ 스크린샷 / GIF / 화면 녹화
<img width="730" alt="스크린샷 2025-04-29 17 22 06" src="https://github.com/user-attachments/assets/e44ff07a-17e5-415f-80b2-4ee2167a4355" />
<img width="734" alt="스크린샷 2025-04-29 17 22 24" src="https://github.com/user-attachments/assets/fc8403d4-361d-4c68-8ded-15a3aabf7849" />

