### PR TITLE
feat: 대출 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     LOAN_NOT_FOUND("L002", "대출 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     APPROVAL_MISSING("L003", "승인 정보가 누락되었습니다.", HttpStatus.BAD_REQUEST),
     LOAN_ALREADY_APPROVED("L004", "이미 승인된 대출입니다.", HttpStatus.CONFLICT),
+    LOAN_STATUS_CONFLICT("L005", "변경을 요청한 상태가 제약 조건에 위배됩니다.", HttpStatus.BAD_REQUEST),
 
     // 인증/인가
     AUTH_REQUIRED_FIELD_MISSING("A000", "필수 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,6 +22,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
     private final ProfileUtil profileUtil;
+
+    /**
+     * 필수 파라미터 누락 에러 처리
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        String code = ErrorCode.AUTH_REQUIRED_FIELD_MISSING.getCode();
+        String message = ErrorCode.AUTH_REQUIRED_FIELD_MISSING.getMessage();
+
+        log.warn("[{}] {} | detail={}", code, message, ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(code, message));
+    }
 
     /**
      * Validation 에러 처리

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -1,8 +1,11 @@
 package com.flexrate.flexrate_back.loan.api;
 
 import com.flexrate.flexrate_back.loan.application.LoanAdminService;
+import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateRequest;
+import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateResponse;
 import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -48,5 +51,33 @@ public class LoanAdminController {
             @RequestParam(defaultValue = "date") String sortBy
     ) {
         return ResponseEntity.ok(loanAdminService.getTransactionHistory(memberId, page, size, sortBy));
+    }
+
+    /**
+     * 대출 상태 변경
+     * @param loanApplicationId 대출 신청 ID
+     * @param request 변경할 대출 상태(status), 변경 사유(reason)
+     * @return 성공 여부
+     * @since 2025.05.02
+     * @author 권민지
+     */
+    @Operation(
+            summary = "대출 상태 변경", description = "관리자가 대출 신청의 상태를 변경합니다.",
+            parameters = {
+                    @Parameter(name = "loanApplicationId", description = "대출 신청 ID", required = true),
+                    @Parameter(name = "request", description = "변경할 대출 상태 및 사유", required = true)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "대출 상태 변경 성공"),
+                    @ApiResponse(responseCode = "404", description = "대출 신청을 찾을 수 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"L002\", \"message\": \"대출 정보를 찾을 수 없습니다.\"}"))),
+                    @ApiResponse(responseCode = "400", description = "대출 상태 변경 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"L005\", \"message\": \"변경을 요청한 상태가 제약 조건에 위배됩니다.\"}")))
+            })
+    @PatchMapping("/{loanApplicationId}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<LoanApplicationStatusUpdateResponse> patchLoanApplicationStatus(
+            @PathVariable("loanApplicationId") Long loanApplicationId,
+            @Valid @RequestBody LoanApplicationStatusUpdateRequest request
+    ) {
+        return ResponseEntity.ok(loanAdminService.patchLoanApplicationStatus(loanApplicationId, request));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -3,7 +3,11 @@ package com.flexrate.flexrate_back.loan.application;
 import com.flexrate.flexrate_back.common.dto.PaginationInfo;
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.loan.application.repository.LoanApplicationRepository;
 import com.flexrate.flexrate_back.loan.application.repository.LoanTransactionQueryRepository;
+import com.flexrate.flexrate_back.loan.domain.LoanApplication;
+import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateRequest;
+import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateResponse;
 import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
 import com.flexrate.flexrate_back.loan.mapper.LoanTransactionMapper;
 import com.flexrate.flexrate_back.member.application.AdminAuthChecker;
@@ -13,11 +17,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LoanAdminService {
     private final LoanTransactionQueryRepository loanTransactionQueryRepository;
+    private final LoanApplicationRepository loanApplicationRepository;
     private final LoanTransactionMapper loanTransactionMapper;
     private final MemberRepository memberRepository;
     private final AdminAuthChecker adminAuthChecker;
@@ -71,4 +78,34 @@ public class LoanAdminService {
                         .toList())
                 .build();
     }
+
+    /**
+     * 대출 상태 변경 updateLoanStatus
+     * @param loanApplicationId 대출 신청 ID
+     * @param request 변경할 대출 상태(status), 변경 사유(reason)
+     * @return 성공 여부
+     */
+    @Transactional
+    public LoanApplicationStatusUpdateResponse patchLoanApplicationStatus(
+            Long loanApplicationId,
+            LoanApplicationStatusUpdateRequest request) {
+        // L002 해당 loanApplicationId 존재 여부 체크
+        if (loanApplicationId == null) {
+            throw new FlexrateException(ErrorCode.LOAN_NOT_FOUND);
+        }
+
+        // L002 loanApplication 데이터 존재여부 체크
+        LoanApplication loanApplication = loanApplicationRepository.findById(loanApplicationId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.LOAN_NOT_FOUND));
+
+        // L005 상태 전환 제약조건 체크 & 상태 변경
+        loanApplication.patchStatus(request.status());
+
+        return LoanApplicationStatusUpdateResponse.builder()
+                .loanApplicationId(loanApplication.getApplicationId())
+                .success(true)
+                .message("대출 상태가 변경되었습니다.")
+                .build();
+    }
+
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanApplicationRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanApplicationRepository.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanApplicationRepository extends JpaRepository<LoanApplication, Long> {
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -1,5 +1,7 @@
 package com.flexrate.flexrate_back.loan.domain;
 
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
 import com.flexrate.flexrate_back.member.domain.Member;
 import jakarta.persistence.*;
@@ -45,4 +47,26 @@ public class LoanApplication {
 
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+
+    // 대출 상태 변경
+    public void patchStatus(LoanApplicationStatus status) {
+        // L005 상태 전환 제약조건 체크
+        if (!isTransitionValid(this.status, status)) {
+            throw new FlexrateException(ErrorCode.LOAN_STATUS_CONFLICT);
+        }
+
+        this.status = status;
+    }
+
+    /**
+     * 대출 상태 전환 유효성 체크
+     * 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED
+     * @param currentStatus 현재 대출 상태
+     * @param newStatus 변경할 대출 상태
+     * @return true: 유효한 상태 전환, false: 유효하지 않은 상태 전환
+     */
+    public boolean isTransitionValid(LoanApplicationStatus currentStatus, LoanApplicationStatus newStatus) {
+        return (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
+                (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED);
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -60,13 +60,13 @@ public class LoanApplication {
 
     /**
      * 대출 상태 전환 유효성 체크
-     * 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED
+     * 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED
      * @param currentStatus 현재 대출 상태
      * @param newStatus 변경할 대출 상태
      * @return true: 유효한 상태 전환, false: 유효하지 않은 상태 전환
      */
     public boolean isTransitionValid(LoanApplicationStatus currentStatus, LoanApplicationStatus newStatus) {
         return (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
-                (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED);
+                (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.COMPLETED);
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanApplicationStatusUpdateRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanApplicationStatusUpdateRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record LoanApplicationStatusUpdateRequest(
-        @NotNull(message = "대출 상태는 필수입니다.(PENDING, APPROVED, REJECTED, EXECUTED)")
+        @NotNull(message = "대출 상태는 필수입니다.(PENDING, REJECTED, EXECUTED, COMPLETED)")
         LoanApplicationStatus status,
 
         String reason

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanApplicationStatusUpdateRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanApplicationStatusUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record LoanApplicationStatusUpdateRequest(
+        @NotNull(message = "대출 상태는 필수입니다.(PENDING, APPROVED, REJECTED, EXECUTED)")
+        LoanApplicationStatus status,
+
+        String reason
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanApplicationStatusUpdateResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanApplicationStatusUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LoanApplicationStatusUpdateResponse(
+        Long loanApplicationId,
+        boolean success,
+        String message
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanApplicationStatus.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanApplicationStatus.java
@@ -2,7 +2,6 @@ package com.flexrate.flexrate_back.loan.enums;
 
 public enum LoanApplicationStatus {
     PENDING,
-    APPROVED,
     REJECTED,
     EXECUTED
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanApplicationStatus.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanApplicationStatus.java
@@ -3,5 +3,6 @@ package com.flexrate.flexrate_back.loan.enums;
 public enum LoanApplicationStatus {
     PENDING,
     REJECTED,
-    EXECUTED
+    EXECUTED,
+    COMPLETED
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -41,7 +41,7 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
                         (request.startDate() != null ? member.createdAt.goe(request.startDate().atStartOfDay()) : null),
                         (request.endDate() != null ? member.createdAt.loe(request.endDate().atTime(23, 59, 59)) : null),
                         request.hasLoan() != null && request.hasLoan()
-                                ? member.loanApplication.status.ne(LoanApplicationStatus.APPROVED) : null,
+                                ? member.loanApplication.status.ne(LoanApplicationStatus.EXECUTED) : null,
                         request.loanTransactionCount() != null
                                 ? request.loanTransactionCount() == 0
                                 ? member.loanApplication.isNull()

--- a/src/test/java/com/flexrate/flexrate_back/loan/application/LoanAdminServiceTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/loan/application/LoanAdminServiceTest.java
@@ -1,0 +1,106 @@
+package com.flexrate.flexrate_back.loan.application;
+
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.loan.application.repository.LoanApplicationRepository;
+import com.flexrate.flexrate_back.loan.domain.LoanApplication;
+import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateRequest;
+import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class LoanAdminServiceTest {
+
+    @Mock
+    private LoanApplicationRepository loanApplicationRepository;
+
+    @InjectMocks
+    private LoanAdminService loanAdminService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("Given 대기중 대출, When EXECUTED로 변경, Then 상태 변경 성공")
+    void changeStatus_success() {
+        // Given
+        Long loanId = 100L;
+        LoanApplication loanApp = LoanApplication.builder()
+                .applicationId(loanId)
+                .status(LoanApplicationStatus.PENDING)
+                .build();
+        when(loanApplicationRepository.findById(loanId)).thenReturn(Optional.of(loanApp));
+        LoanApplicationStatusUpdateRequest request = new LoanApplicationStatusUpdateRequest(LoanApplicationStatus.EXECUTED, null);
+
+        // When
+        var response = loanAdminService.patchLoanApplicationStatus(loanId, request);
+
+        // Then
+        assertThat(response.success()).isTrue();
+        assertThat(loanApp.getStatus()).isEqualTo(LoanApplicationStatus.EXECUTED);
+        assertThat(response.message()).isEqualTo("대출 상태가 변경되었습니다.");
+    }
+
+    @Test
+    @DisplayName("Given 없는 대출, When 상태 변경 요청, Then L002 예외 발생")
+    void changeStatus_notFound() {
+        // Given
+        Long loanId = 999L;
+        when(loanApplicationRepository.findById(loanId)).thenReturn(Optional.empty());
+        LoanApplicationStatusUpdateRequest request = new LoanApplicationStatusUpdateRequest(LoanApplicationStatus.EXECUTED, null);
+
+        // When & Then
+        assertThatThrownBy(() -> loanAdminService.patchLoanApplicationStatus(loanId, request))
+                .isInstanceOf(FlexrateException.class)
+                .hasMessageContaining(ErrorCode.LOAN_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("Given 이미 EXECUTED, When EXECUTED로 변경, Then L005 예외 발생")
+    void changeStatus_duplicate() {
+        // Given
+        Long loanId = 101L;
+        LoanApplication loanApp = LoanApplication.builder()
+                .applicationId(loanId)
+                .status(LoanApplicationStatus.EXECUTED)
+                .build();
+        when(loanApplicationRepository.findById(loanId)).thenReturn(Optional.of(loanApp));
+        LoanApplicationStatusUpdateRequest request = new LoanApplicationStatusUpdateRequest(LoanApplicationStatus.EXECUTED, null);
+
+        // When & Then
+        assertThatThrownBy(() -> loanAdminService.patchLoanApplicationStatus(loanId, request))
+                .isInstanceOf(FlexrateException.class)
+                .hasMessageContaining(ErrorCode.LOAN_STATUS_CONFLICT.getMessage());
+    }
+
+    @Test
+    @DisplayName("Given EXECUTED, When PENDING로 변경, Then L005 예외 발생")
+    void changeStatus_invalidTransition() {
+        // Given
+        Long loanId = 102L;
+        LoanApplication loanApp = LoanApplication.builder()
+                .applicationId(loanId)
+                .status(LoanApplicationStatus.EXECUTED)
+                .build();
+        when(loanApplicationRepository.findById(loanId)).thenReturn(Optional.of(loanApp));
+        LoanApplicationStatusUpdateRequest request = new LoanApplicationStatusUpdateRequest(LoanApplicationStatus.PENDING, "사유");
+
+        // When & Then
+        assertThatThrownBy(() -> loanAdminService.patchLoanApplicationStatus(loanId, request))
+                .isInstanceOf(FlexrateException.class)
+                .hasMessageContaining(ErrorCode.LOAN_STATUS_CONFLICT.getMessage());
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #28

---

## 💜 작업 내용

- [x] `LoanAdminController`: 대출 신청 상태 변경 기능 구현
- [x] `LoanAdminService`, `LoanApplication`: 상태 전환 비즈니스 로직 및 검증 추가
- [x] 요청/응답 DTO 정의 및 적용
- [x] 예외 처리 및 오류 코드 개선
- [x] 단위 테스트 작성

---

## ✅ PR Point

- 유효한 상태 전환만 허용하도록 유효성 체크 메서드를 엔티티에 추가했습니다. 불가능한 전환 시 LOAN_STATUS_CONFLICT 오류 코드가 반환됩니다.
   - 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED

- 리뷰 집중 포인트:
    - 상태 전환 규칙이 충분한가?
    - 예외 및 오류 코드가 명확하게 정의/처리되는가?

---

## 😡 Trouble Shooting

기존 예외 코드와 메시지가 혼재되어 있어 새로운 ErrorCode를 정의하고, 모든 예외 발생 지점에서 이를 사용하도록 리팩토링했습니다. (필수 파라미터 누락 에러 처리)

---

## ☀ 스크린샷 / GIF / 화면 녹화
- L002 LOAN_NOT_FOUND
   <img width="529" alt="스크린샷 2025-05-02 12 38 54" src="https://github.com/user-attachments/assets/b153ae07-cdeb-4443-bfdd-fd0951317d54" />


- L005 LOAN_STATUS_CONFLICT
   <img width="586" alt="스크린샷 2025-05-02 12 46 26" src="https://github.com/user-attachments/assets/70f85563-c644-4aa6-9571-20d8616db4d1" />


- A000 AUTH_REQUIRED_FIELD_MISSING
   <img width="527" alt="스크린샷 2025-05-02 12 38 39" src="https://github.com/user-attachments/assets/f125f257-1fd8-490b-80a8-f87657852a03" />


- 200 OK
   <img width="537" alt="스크린샷 2025-05-02 14 11 34" src="https://github.com/user-attachments/assets/cd61893a-ecb4-4e5b-b933-95f0a6be7078" />
