### PR TITLE
chore: JWT 인증/인가 구현 및 Swagger, Spring Security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,17 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 	implementation 'org.flywaydb:flyway-mysql'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.7'
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.96.Final:osx-aarch_64'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties["querydsl.version"]}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties["querydsl.version"]}:jakarta"
@@ -61,11 +60,13 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
@@ -1,6 +1,7 @@
 package com.flexrate.flexrate_back;
 
 import com.flexrate.flexrate_back.auth.domain.jwt.JwtProperties;
+import com.flexrate.flexrate_back.common.config.SecurityConfigProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, SecurityConfigProperties.class})
 public class FlexrateBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
@@ -1,11 +1,14 @@
 package com.flexrate.flexrate_back;
 
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
 public class FlexrateBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/flexrate/flexrate_back/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.flexrate.flexrate_back.auth;
+
+import com.flexrate.flexrate_back.auth.domain.jwt.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByRefreshToken(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/api/TestTokenApiController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/TestTokenApiController.java
@@ -1,0 +1,139 @@
+package com.flexrate.flexrate_back.auth.api;
+
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
+import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenResponse;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Role;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 테스트용 API
+ * @author 유승한
+ * @since 2025.05.01
+ */
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class TestTokenApiController {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+
+    @Operation(summary = "임의 토큰 발급", description = "로그인 기능이 없을 때 테스트용으로 JWT 발급하는 API입니다.")
+    @PostMapping("/auth/generate-dev-token")
+    public ResponseEntity<CreateAccessTokenResponse> generateDevToken(
+            @RequestParam(defaultValue = "1") Long memberId,
+            @RequestParam(defaultValue = "MEMBER") Role role) {
+
+        Member fakeMember = Member.builder()
+                .memberId(memberId)
+                .email("test@dev.com")
+                .passwordHash("test")
+                .name("개발자")
+                .phone("010-0000-0000")
+                .sex(Sex.MALE)
+                .role(role)
+                .status(MemberStatus.ACTIVE)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        String token = jwtTokenProvider.generateToken(fakeMember, Duration.ofHours(1));
+
+        return ResponseEntity.ok(new CreateAccessTokenResponse(token));
+    }
+
+    @GetMapping("/auth/test-token")
+    @Operation(
+            summary = "현재 사용자 정보 조회",
+            description = "테스트용으로 요청 헤더에 포함된 JWT 토큰을 기반으로 사용자 인증 정보를 반환합니다.",
+            security = { @SecurityRequirement(name = "Bearer Authentication") }
+    )
+    public ResponseEntity<String> getCurrentUser(HttpServletRequest request) {
+        String token = resolveToken(request);
+        if (token != null && jwtTokenProvider.validToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            String userInfo = String.format("인증된 사용자: %s, 권한: %s",
+                    auth.getName(),
+                    auth.getAuthorities().toString()
+            );
+            return ResponseEntity.ok(userInfo);
+        } else {
+            return ResponseEntity.status(401).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    @Operation(
+            summary = "현재 사용자 상세 정보 조회",
+            description = "JWT 토큰을 기반으로 Principal에서 사용자 ID를 추출하여 Member 정보를 조회합니다.",
+            security = { @SecurityRequirement(name = "Bearer Authentication") },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"code\": \"A004\", \"message\": \"유효하지 않은 리프레시 토큰입니다.\"}")
+                    )),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"code\": \"S500\", \"message\": \"서버 내부 오류\"}")
+                    ))
+            }
+    )
+    @GetMapping("/test-principal")
+    public ResponseEntity<Member> getMyMemberInfo(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.AUTH_REQUIRED_FIELD_MISSING);
+        }
+
+        Member member = getMember(principal);
+        return ResponseEntity.ok(member);
+    }
+
+    // 본래 getMember이지만 테스트 api 상 principal의 id 가 1일 시 fakeMember 반환
+    private Member getMember(Principal principal) {
+        if(!principal.getName().equals("1")) throw new FlexrateException(ErrorCode.USER_NOT_FOUND);
+        Member fakeMember = Member.builder()
+                .memberId(1l)
+                .email("test@dev.com")
+                .passwordHash("test")
+                .name("개발자")
+                .phone("010-0000-0000")
+                .sex(Sex.MALE)
+                .role(Role.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+//        return memberService.findById(Long.parseLong(principal.getName()));
+        return fakeMember;
+    }
+
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
@@ -3,18 +3,53 @@ package com.flexrate.flexrate_back.auth.api;
 import com.flexrate.flexrate_back.auth.application.TokenService;
 import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenRequest;
 import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+/**
+ * 액세스 토큰 발급 API
+ * @author 유승한
+ * @since 2025.05.01
+ */
 
 @RequiredArgsConstructor
 @RestController
 public class TokenApiController {
     private final TokenService tokenService;
 
+    /**
+     * 리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.
+     *
+     * @param request 리프레시 토큰 요청 DTO
+     * @return 생성된 액세스 토큰
+     * @throws IllegalArgumentException 유효하지 않은 토큰일 경우 예외 발생
+     */
+    @Operation(
+            summary = "액세스 토큰 재발급",
+            description = "리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.",
+            parameters = {
+                    @Parameter(name = "request", description = "리프레시 토큰 요청 DTO", required = true)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "액세스 토큰 발급 성공"),
+                    @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰", content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"code\": \"A001\", \"message\": \"유효하지 않은 토큰입니다.\"}")
+                    )),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = "{\"code\": \"S500\", \"message\": \"서버 내부 오류\"}")
+                    ))
+            }
+    )
     @PostMapping("/api/token")
     public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(@RequestBody CreateAccessTokenRequest request){
         String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());

--- a/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
@@ -1,43 +1,50 @@
 package com.flexrate.flexrate_back.auth.api;
 
 import com.flexrate.flexrate_back.auth.application.TokenService;
-import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenRequest;
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
 import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenResponse;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Role;
+import com.flexrate.flexrate_back.member.enums.Sex;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 /**
  * 액세스 토큰 발급 API
  * @author 유승한
  * @since 2025.05.01
  */
-
 @RequiredArgsConstructor
-@RestController
+@RestController("/api/auth")
 public class TokenApiController {
     private final TokenService tokenService;
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.
      *
-     * @param request 리프레시 토큰 요청 DTO
      * @return 생성된 액세스 토큰
      * @throws IllegalArgumentException 유효하지 않은 토큰일 경우 예외 발생
      */
     @Operation(
             summary = "액세스 토큰 재발급",
-            description = "리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.",
-            parameters = {
-                    @Parameter(name = "request", description = "리프레시 토큰 요청 DTO", required = true)
-            },
+            description = "쿠키에 저장된 리프레시 토큰으로 액세스 토큰을 재발급하는 API <br>파라미터 필요없이 execute 하면 됩니다",
             responses = {
                     @ApiResponse(responseCode = "201", description = "액세스 토큰 발급 성공"),
                     @ApiResponse(responseCode = "400", description = "유효하지 않은 토큰", content = @Content(
@@ -50,10 +57,71 @@ public class TokenApiController {
                     ))
             }
     )
-    @PostMapping("/api/token")
-    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(@RequestBody CreateAccessTokenRequest request){
-        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+    @PostMapping("/token")
+    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(@CookieValue(value = "refresh_token", required = false) String refreshToken){
+        if (refreshToken == null) {
+            throw new FlexrateException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        String newAccessToken = tokenService.createNewAccessToken(refreshToken);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(new CreateAccessTokenResponse(newAccessToken));
     }
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "임의 토큰 발급", description = "로그인 기능이 없을 때 테스트용으로 JWT 발급하는 API입니다.")
+    @PostMapping("/generate-dev-token")
+    public ResponseEntity<CreateAccessTokenResponse> generateDevToken(
+            @RequestParam(defaultValue = "1") Long memberId,
+            @RequestParam(defaultValue = "MEMBER") Role role) {
+
+        Member fakeMember = Member.builder()
+                .memberId(memberId)
+                .email("test@dev.com")
+                .passwordHash("test")
+                .name("개발자")
+                .phone("010-0000-0000")
+                .sex(Sex.MALE)
+                .role(role)
+                .status(MemberStatus.ACTIVE)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        String token = jwtTokenProvider.generateToken(fakeMember, Duration.ofHours(1));
+
+        return ResponseEntity.ok(new CreateAccessTokenResponse(token));
+    }
+
+    @GetMapping("/test-token")
+    @Operation(
+            summary = "현재 사용자 정보 조회",
+            description = "테스트용으로 요청 헤더에 포함된 JWT 토큰을 기반으로 사용자 인증 정보를 반환합니다.",
+            security = { @SecurityRequirement(name = "Bearer Authentication") }
+    )
+    public ResponseEntity<String> getCurrentUser(HttpServletRequest request) {
+        String token = resolveToken(request);
+        if (token != null && jwtTokenProvider.validToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            String userInfo = String.format("인증된 사용자: %s, 권한: %s",
+                    auth.getName(),
+                    auth.getAuthorities().toString()
+            );
+            return ResponseEntity.ok(userInfo);
+        } else {
+            return ResponseEntity.status(401).body("❌ 유효하지 않은 토큰입니다.");
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
@@ -1,0 +1,24 @@
+package com.flexrate.flexrate_back.auth.api;
+
+import com.flexrate.flexrate_back.auth.application.TokenService;
+import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenRequest;
+import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TokenApiController {
+    private final TokenService tokenService;
+
+    @PostMapping("/api/token")
+    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(@RequestBody CreateAccessTokenRequest request){
+        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(new CreateAccessTokenResponse(newAccessToken));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/TokenApiController.java
@@ -1,30 +1,20 @@
 package com.flexrate.flexrate_back.auth.api;
 
 import com.flexrate.flexrate_back.auth.application.TokenService;
-import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
 import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenResponse;
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
-import com.flexrate.flexrate_back.member.domain.Member;
-import com.flexrate.flexrate_back.member.enums.MemberStatus;
-import com.flexrate.flexrate_back.member.enums.Role;
-import com.flexrate.flexrate_back.member.enums.Sex;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 액세스 토큰 발급 API
@@ -32,9 +22,11 @@ import java.time.LocalDateTime;
  * @since 2025.05.01
  */
 @RequiredArgsConstructor
-@RestController("/api/auth")
+@RequestMapping("/api/auth")
+@RestController
 public class TokenApiController {
     private final TokenService tokenService;
+
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.
@@ -67,61 +59,4 @@ public class TokenApiController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(new CreateAccessTokenResponse(newAccessToken));
     }
-
-    private final JwtTokenProvider jwtTokenProvider;
-
-    @Operation(summary = "임의 토큰 발급", description = "로그인 기능이 없을 때 테스트용으로 JWT 발급하는 API입니다.")
-    @PostMapping("/generate-dev-token")
-    public ResponseEntity<CreateAccessTokenResponse> generateDevToken(
-            @RequestParam(defaultValue = "1") Long memberId,
-            @RequestParam(defaultValue = "MEMBER") Role role) {
-
-        Member fakeMember = Member.builder()
-                .memberId(memberId)
-                .email("test@dev.com")
-                .passwordHash("test")
-                .name("개발자")
-                .phone("010-0000-0000")
-                .sex(Sex.MALE)
-                .role(role)
-                .status(MemberStatus.ACTIVE)
-                .birthDate(LocalDate.of(1990, 1, 1))
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-
-        String token = jwtTokenProvider.generateToken(fakeMember, Duration.ofHours(1));
-
-        return ResponseEntity.ok(new CreateAccessTokenResponse(token));
-    }
-
-    @GetMapping("/test-token")
-    @Operation(
-            summary = "현재 사용자 정보 조회",
-            description = "테스트용으로 요청 헤더에 포함된 JWT 토큰을 기반으로 사용자 인증 정보를 반환합니다.",
-            security = { @SecurityRequirement(name = "Bearer Authentication") }
-    )
-    public ResponseEntity<String> getCurrentUser(HttpServletRequest request) {
-        String token = resolveToken(request);
-        if (token != null && jwtTokenProvider.validToken(token)) {
-            Authentication auth = jwtTokenProvider.getAuthentication(token);
-            String userInfo = String.format("인증된 사용자: %s, 권한: %s",
-                    auth.getName(),
-                    auth.getAuthorities().toString()
-            );
-            return ResponseEntity.ok(userInfo);
-        } else {
-            return ResponseEntity.status(401).body("❌ 유효하지 않은 토큰입니다.");
-        }
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
-
-
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/RefreshTokenService.java
@@ -1,0 +1,17 @@
+package com.flexrate.flexrate_back.auth.application;
+
+import com.flexrate.flexrate_back.auth.domain.repository.RefreshTokenRepository;
+import com.flexrate.flexrate_back.auth.domain.jwt.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(()-> new IllegalArgumentException("Unexpected token"));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/RefreshTokenService.java
@@ -10,8 +10,17 @@ import org.springframework.stereotype.Service;
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
+    /**
+     * 관리자 권한으로 회원 목록 조회
+     *
+     * @param refreshToken 클라이언트로부터 전달받은 리프레시 토큰
+     * @return RefreshToken 토큰 정보 객체
+     * @throws IllegalArgumentException 유효하지 않은 리프레시 토큰일 경우
+     * @since 2025.05.01
+     * @author 유승한
+     */
     public RefreshToken findByRefreshToken(String refreshToken) {
         return refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(()-> new IllegalArgumentException("Unexpected token"));
+                .orElseThrow(() -> new IllegalArgumentException("Unexpected token"));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/RefreshTokenService.java
@@ -2,6 +2,8 @@ package com.flexrate.flexrate_back.auth.application;
 
 import com.flexrate.flexrate_back.auth.domain.repository.RefreshTokenRepository;
 import com.flexrate.flexrate_back.auth.domain.jwt.RefreshToken;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +23,6 @@ public class RefreshTokenService {
      */
     public RefreshToken findByRefreshToken(String refreshToken) {
         return refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("Unexpected token"));
+                .orElseThrow(() -> new FlexrateException(ErrorCode.INVALID_REFRESH_TOKEN));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/TokenService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/TokenService.java
@@ -13,12 +13,11 @@ import java.time.Duration;
 @Service
 public class TokenService {
     private final JwtTokenProvider tokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final MemberService memberService;
     private final RefreshTokenService refreshTokenService;
 
     /**
-     * 관리자 권한으로 회원 목록 조회
+     * 리프레쉬 토큰으로 액세스 토큰 재발급
      *
      * @param refreshToken 클라이언트로부터 전달받은 리프레시 토큰
      * @return 새로 발급된 액세스 토큰 문자열

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/TokenService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/TokenService.java
@@ -1,0 +1,29 @@
+package com.flexrate.flexrate_back.auth.application;
+
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
+import com.flexrate.flexrate_back.auth.domain.repository.RefreshTokenRepository;
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+    private final JwtTokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberService memberService;
+    private final RefreshTokenService refreshTokenService;
+
+    public String createNewAccessToken(String refreshToken) {
+        // 토큰 유효성 검사 실패 시 예외 발생
+        if(!tokenProvider.validToken(refreshToken)){
+            throw new IllegalArgumentException("Unexpected token");
+        }
+        Long memberId = refreshTokenService.findByRefreshToken(refreshToken).getMemberId();
+        Member member = memberService.findById(memberId);
+
+        return tokenProvider.generateToken(member, Duration.ofHours(2));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/TokenService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/TokenService.java
@@ -6,6 +6,7 @@ import com.flexrate.flexrate_back.member.application.MemberService;
 import com.flexrate.flexrate_back.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 import java.time.Duration;
 
 @RequiredArgsConstructor
@@ -16,9 +17,18 @@ public class TokenService {
     private final MemberService memberService;
     private final RefreshTokenService refreshTokenService;
 
+    /**
+     * 관리자 권한으로 회원 목록 조회
+     *
+     * @param refreshToken 클라이언트로부터 전달받은 리프레시 토큰
+     * @return 새로 발급된 액세스 토큰 문자열
+     * @throws IllegalArgumentException 유효하지 않은 토큰일 경우
+     * @since 2025.05.01
+     * @author 유승한
+     */
     public String createNewAccessToken(String refreshToken) {
         // 토큰 유효성 검사 실패 시 예외 발생
-        if(!tokenProvider.validToken(refreshToken)){
+        if (!tokenProvider.validToken(refreshToken)) {
             throw new IllegalArgumentException("Unexpected token");
         }
         Long memberId = refreshTokenService.findByRefreshToken(refreshToken).getMemberId();

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package com.flexrate.flexrate_back.auth.domain.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"code\": \"A002\", \"message\": \"접근 권한이 없습니다.\"}");
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,4 @@
+package com.flexrate.flexrate_back.auth.domain.jwt;
+
+public class JwtAuthenticationEntryPoint {
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,24 @@
 package com.flexrate.flexrate_back.auth.domain.jwt;
 
-public class JwtAuthenticationEntryPoint {
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException)
+            throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"code\": \"A003\", \"message\": \"인증되지 않은 사용자입니다.\"}");
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtProperties.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.flexrate.flexrate_back.auth.domain.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secretKey;
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.flexrate.flexrate_back.auth.domain.jwt;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    private final JwtProperties jwtProperties;
+
+    public String generateToken(Member member, Duration expiredAt) {
+        Date now = new Date();
+        return makeToken(new Date(now.getTime() + expiredAt.toMillis()), member);
+    }
+    /**
+     * JWT 토큰을 생성하는 메서드이다.
+     * @param expiry 토큰의 만료 시간
+     * @param member 회원 정보
+     * @return 생성된 토큰
+     */
+    private String makeToken(Date expiry, Member member) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) //헤더 타입 : jwt
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .setSubject(String.valueOf(member.getMemberId()))
+                .claim("id", member.getMemberId())
+                .claim("role", member.getRole().name())
+                // 서명 : 시크릿 키와 함께 해시값을 hs256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+
+    public boolean validToken(String token) {
+        try{
+            Jwts.parser()
+                    .setSigningKey(jwtProperties.getSecretKey())
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    // 토큰 기반으로 인증 정보를 가져오는 메서드
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    // 토큰 기반으로 유저 id를 가져오는 메서드
+    public Long getMemberId(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("id", Long.class);
+    }
+
+    //
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/RefreshToken.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/RefreshToken.java
@@ -1,0 +1,32 @@
+package com.flexrate.flexrate_back.auth.domain.jwt;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long tokenId;
+
+    @Column(name="member_id", nullable=false, unique = true)
+    private Long memberId;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(Long memberId, String refreshToken) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshToken update(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+        return this;
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/TokenAuthenticationFilter.java
@@ -27,8 +27,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         // 가져온 값에서 접두사 제거
         String token = getAccessToken(authorizationHeader);
         // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
-        if(tokenProvider.validToken(authorizationHeader)) {
-            Authentication auth = tokenProvider.getAuthentication(authorizationHeader);
+        if (token != null && tokenProvider.validToken(token)) {
+            Authentication auth = tokenProvider.getAuthentication(token);
+
             SecurityContextHolder.getContext().setAuthentication(auth);
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/TokenAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.flexrate.flexrate_back.auth.domain.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider tokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException{
+        // 요청 헤더의 authorization 키의 값 조회
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+        // 가져온 값에서 접두사 제거
+        String token = getAccessToken(authorizationHeader);
+        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
+        if(tokenProvider.validToken(authorizationHeader)) {
+            Authentication auth = tokenProvider.getAuthentication(authorizationHeader);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAccessToken(String authorizationHeader) {
+        if(authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/repository/RefreshTokenRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByRefreshToken(Long userId);
+    Optional<RefreshToken> findByMemberId(Long memberId);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/repository/RefreshTokenRepository.java
@@ -1,4 +1,4 @@
-package com.flexrate.flexrate_back.auth;
+package com.flexrate.flexrate_back.auth.domain.repository;
 
 import com.flexrate.flexrate_back.auth.domain.jwt.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/flexrate/flexrate_back/auth/dto/CreateAccessTokenRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/dto/CreateAccessTokenRequest.java
@@ -1,11 +1,10 @@
 package com.flexrate.flexrate_back.auth.dto;
 
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class CreateAccessTokenRequest {
     private String refreshToken;
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/dto/CreateAccessTokenRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/dto/CreateAccessTokenRequest.java
@@ -1,0 +1,11 @@
+package com.flexrate.flexrate_back.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateAccessTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/dto/CreateAccessTokenResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/dto/CreateAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreateAccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfig.java
@@ -1,27 +1,65 @@
 package com.flexrate.flexrate_back.common.config;
 
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtAccessDeniedHandler;
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtAuthenticationEntryPoint;
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
+import com.flexrate.flexrate_back.auth.domain.jwt.TokenAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers(
-                            "/**"
-                    ).permitAll()
-                    .anyRequest().authenticated()
-            )
-            .sessionManagement(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable);
+    private final JwtTokenProvider jwtTokenProvider;
+    private final SecurityConfigProperties securityConfigProperties;
 
-        // JWT 인증 필터 추가 필요
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/**") // 모든 요청에 대해 필터 적용
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new TokenAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(sess -> sess.sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                        .accessDeniedHandler(new JwtAccessDeniedHandler())
+                );
+
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(securityConfigProperties.getAllowedOrigins());
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfigProperties.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfigProperties.java
@@ -1,0 +1,16 @@
+package com.flexrate.flexrate_back.common.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@ConfigurationProperties(prefix = "security")
+public class SecurityConfigProperties {
+    private List<String> allowedOrigins;
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/common/config/SwaggerConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/SwaggerConfig.java
@@ -1,12 +1,59 @@
 package com.flexrate.flexrate_back.common.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@SecurityScheme(
+        name = "Bearer Authentication",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
+@OpenAPIDefinition(security = { @SecurityRequirement(name = "Bearer Authentication") })
 public class SwaggerConfig {
+    @Bean
+    public GlobalOpenApiCustomizer globalErrorResponses() {
+        return openApi -> openApi.getPaths().values().forEach(pathItem ->
+                pathItem.readOperations().forEach(operation -> {
+                    ApiResponses responses = operation.getResponses();
+
+                    ApiResponse error400 = new ApiResponse()
+                            .description("잘못된 요청 - 필드 누락 또는 형식 오류")
+                            .content(new Content().addMediaType("application/json",
+                                    new io.swagger.v3.oas.models.media.MediaType()
+                                            .schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))));
+
+                    ApiResponse error401 = new ApiResponse()
+                            .description("인증 실패 - 토큰 누락/만료")
+                            .content(new Content().addMediaType("application/json",
+                                    new io.swagger.v3.oas.models.media.MediaType()
+                                            .schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))));
+
+                    ApiResponse error500 = new ApiResponse()
+                            .description("서버 내부 오류")
+                            .content(new Content().addMediaType("application/json",
+                                    new io.swagger.v3.oas.models.media.MediaType()
+                                            .schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))));
+
+                    responses.addApiResponse("400", error400);
+                    responses.addApiResponse("401", error401);
+                    responses.addApiResponse("500", error500);
+                }));
+    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/src/main/java/com/flexrate/flexrate_back/common/config/SwaggerConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/SwaggerConfig.java
@@ -3,13 +3,11 @@ package com.flexrate.flexrate_back.common.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.models.media.Content;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -30,25 +28,12 @@ public class SwaggerConfig {
         return openApi -> openApi.getPaths().values().forEach(pathItem ->
                 pathItem.readOperations().forEach(operation -> {
                     ApiResponses responses = operation.getResponses();
-
                     ApiResponse error400 = new ApiResponse()
-                            .description("잘못된 요청 - 필드 누락 또는 형식 오류")
-                            .content(new Content().addMediaType("application/json",
-                                    new io.swagger.v3.oas.models.media.MediaType()
-                                            .schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))));
-
+                            .description("잘못된 요청 - 필드 누락 또는 형식 오류");
                     ApiResponse error401 = new ApiResponse()
-                            .description("인증 실패 - 토큰 누락/만료")
-                            .content(new Content().addMediaType("application/json",
-                                    new io.swagger.v3.oas.models.media.MediaType()
-                                            .schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))));
-
+                            .description("인증 실패 - 토큰 누락/만료");
                     ApiResponse error500 = new ApiResponse()
-                            .description("서버 내부 오류")
-                            .content(new Content().addMediaType("application/json",
-                                    new io.swagger.v3.oas.models.media.MediaType()
-                                            .schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))));
-
+                            .description("서버 내부 오류");
                     responses.addApiResponse("400", error400);
                     responses.addApiResponse("401", error401);
                     responses.addApiResponse("500", error500);

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     INVALID_EMAIL_FORMAT("A005", "올바르지 않은 이메일 형식입니다.", HttpStatus.BAD_REQUEST),
     AUTHENTICATION_REQUIRED("A006", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     ADMIN_AUTH_REQUIRED("A007", "관리자 권한이 필요합니다.", HttpStatus.FORBIDDEN),
+    REFRESH_TOKEN_NOT_FOUND("A008", "리프레쉬 토큰이 누락되었습니다.", HttpStatus.BAD_REQUEST),
 
     // 상품
     PRODUCT_LOAD_ERROR("P001", "상품을 불러오는 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.flexrate.flexrate_back.common.exception;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "에러 응답 DTO")
+public class ErrorResponse {
+
+    @Schema(description = "에러 코드", example = "U001")
+    private String code;
+
+    @Schema(description = "에러 메시지", example = "사용자를 찾을 수 없습니다")
+    private String message;
+}

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "에러 응답 DTO")
+@Schema(description = "에러 응답")
 public class ErrorResponse {
 
     @Schema(description = "에러 코드", example = "U001")

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -1,5 +1,7 @@
 package com.flexrate.flexrate_back.member.application;
 
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,6 @@ public class MemberService {
 
     public Member findById(Long memberId) {
     return memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("Unexpected member"));
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -1,0 +1,17 @@
+package com.flexrate.flexrate_back.member.application;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    MemberRepository memberRepository;
+
+    public Member findById(Long memberId) {
+    return memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Unexpected member"));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class MemberService {
-    MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
     public Member findById(Long memberId) {
     return memberRepository.findById(memberId)

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.flexrate.flexrate_back.member.domain;
 
 import com.flexrate.flexrate_back.member.enums.LoginMethod;
+import com.flexrate.flexrate_back.member.enums.Role;
 import com.flexrate.flexrate_back.member.enums.Sex;
 import com.flexrate.flexrate_back.member.enums.MemberStatus;
 import com.flexrate.flexrate_back.loan.domain.LoanApplication;
@@ -42,6 +43,10 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Sex sex;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     private LocalDate birthDate;
 

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package com.flexrate.flexrate_back.member.domain.repository;
 import com.flexrate.flexrate_back.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     // 기본 CRUD 메서드 제공
+    Optional<Member> findByName(String name);
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/enums/Role.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/enums/Role.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.member.enums;
+
+public enum Role {
+    ADMIN,
+    MEMBER;
+
+    public String getAuthority() {
+        return "ROLE_" + this.name();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/security/MemberDetails.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/security/MemberDetails.java
@@ -1,0 +1,44 @@
+package com.flexrate.flexrate_back.member.security;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class MemberDetails implements UserDetails {
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(member.getRole().toString()));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPasswordHash();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+
+    @Override public boolean isAccountNonLocked() { return true; }
+
+    @Override public boolean isCredentialsNonExpired() { return true; }
+
+    @Override public boolean isEnabled() {
+        return member.getStatus() == MemberStatus.ACTIVE; // 예시
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,6 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
     operationsSorter: method
+security:
+  allowed-origins:
+    - http://localhost:3000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
       leak-detection-threshold: 2000
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
@@ -45,6 +45,8 @@ spring:
   sql:
     init:
       mode: always
+jwt:
+  secretKey: ${JWT_SECRET_KEY}
 logging:
   level:
     root: INFO

--- a/src/test/java/com/flexrate/flexrate_back/jwt/JwtFactory.java
+++ b/src/test/java/com/flexrate/flexrate_back/jwt/JwtFactory.java
@@ -1,0 +1,52 @@
+package com.flexrate.flexrate_back.jwt;
+
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtProperties;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class JwtFactory {
+
+    private String subject = "1"; // memberId를 subject로 사용
+    private Date issuedAt = new Date();
+    private Date expiration = new Date(new Date().getTime() + Duration.ofDays(14).toMillis());
+    private Map<String, Object> claims = new HashMap<>();
+
+    @Builder
+    public JwtFactory(String subject, Date issuedAt, Date expiration, Map<String, Object> claims) {
+        if (subject != null) this.subject = subject;
+        if (issuedAt != null) this.issuedAt = issuedAt;
+        if (expiration != null) this.expiration = expiration;
+        if (claims != null) this.claims = claims;
+    }
+
+    public static JwtFactory withDefaultValues() {
+        Map<String, Object> defaultClaims = new HashMap<>();
+        defaultClaims.put("id", 1L);
+        defaultClaims.put("role", "USER");
+
+        return JwtFactory.builder()
+                .subject("1")
+                .claims(defaultClaims)
+                .build();
+    }
+
+    public String createToken(JwtProperties jwtProperties) {
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(subject)
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiration)
+                .addClaims(claims)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+}

--- a/src/test/java/com/flexrate/flexrate_back/jwt/TokenApiControllerTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/jwt/TokenApiControllerTest.java
@@ -1,0 +1,92 @@
+package com.flexrate.flexrate_back.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtProperties;
+import com.flexrate.flexrate_back.auth.domain.jwt.RefreshToken;
+import com.flexrate.flexrate_back.auth.domain.repository.RefreshTokenRepository;
+import com.flexrate.flexrate_back.auth.dto.CreateAccessTokenRequest;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Role;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TokenApiControllerTest {
+    @Autowired
+    protected MockMvc mockMvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    JwtProperties jwtProperties;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @BeforeEach
+    public void mockMvcSetUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+        memberRepository.deleteAll();
+    }
+
+    @DisplayName("createNewAccessToken: 새로운 액세스 토큰을 발급한다.")
+    @Test
+    public void createNewAccessToken() throws Exception {
+        // given
+        final String url = "/api/token";
+
+        Member testUser = memberRepository.save(Member.builder()
+                .email("user@gmail.com")
+                .passwordHash("test")
+                .name("테스트")
+                .phone("010-1234-5678")
+                .sex(Sex.MALE)
+                .role(Role.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build());
+
+        String refreshToken = JwtFactory.builder()
+                .claims(Map.of("id", testUser.getMemberId()))
+                .build()
+                .createToken(jwtProperties);
+        refreshTokenRepository.save(new RefreshToken(testUser.getMemberId(), refreshToken));
+        CreateAccessTokenRequest request = CreateAccessTokenRequest.builder().refreshToken(refreshToken).build();
+        final String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(requestBody));
+
+        // then
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty());
+    }
+}

--- a/src/test/java/com/flexrate/flexrate_back/jwt/TokenProviderTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/jwt/TokenProviderTest.java
@@ -8,8 +8,6 @@ import com.flexrate.flexrate_back.member.enums.MemberStatus;
 import com.flexrate.flexrate_back.member.enums.Role;
 import com.flexrate.flexrate_back.member.enums.Sex;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +19,6 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 

--- a/src/test/java/com/flexrate/flexrate_back/jwt/TokenProviderTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/jwt/TokenProviderTest.java
@@ -1,0 +1,143 @@
+package com.flexrate.flexrate_back.jwt;
+
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtProperties;
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.member.enums.MemberStatus;
+import com.flexrate.flexrate_back.member.enums.Role;
+import com.flexrate.flexrate_back.member.enums.Sex;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+class TokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider tokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @DisplayName("JWT SECRET KEY(): 제대로 시크릿키를 인식한다.")
+    @Test
+    void test(){
+        System.out.println("JWT Secret Key >>> " + jwtProperties.getSecretKey());
+    }
+
+    @DisplayName("generateToken(): 유저 정보와 만료 기간을 전달해 토큰을 만들 수 있다.")
+    @Test
+    void generateToken() {
+        // given
+        Member testUser = memberRepository.save(Member.builder()
+                .email("user@gmail.com")
+                .passwordHash("test")
+                .name("테스트")
+                .phone("010-1234-5678")
+                .sex(Sex.MALE)
+                .role(Role.MEMBER)
+                .status(MemberStatus.ACTIVE)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        String token = tokenProvider.generateToken(testUser, Duration.ofDays(14));
+
+        // then
+        Long memberId = Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Long.class);
+
+        assertThat(memberId).isEqualTo(testUser.getMemberId());
+    }
+
+    @DisplayName("validToken(): 만료된 토큰인 경우에 유효성 검증에 실패한다.")
+    @Test
+    void validToken_invalidToken() {
+        // given
+        String token = JwtFactory.builder()
+                .expiration(new Date(System.currentTimeMillis() - Duration.ofDays(1).toMillis()))
+                .build()
+                .createToken(jwtProperties);
+
+        // when
+        boolean result = tokenProvider.validToken(token);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("validToken(): 유효한 토큰인 경우에 유효성 검증에 성공한다.")
+    @Test
+    void validToken_validToken() {
+        // given
+        String token = JwtFactory.withDefaultValues()
+                .createToken(jwtProperties);
+
+        // when
+        boolean result = tokenProvider.validToken(token);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("getAuthentication(): 토큰 기반으로 인증정보를 가져올 수 있다.")
+    @Test
+    void getAuthentication() {
+        // given
+        String userId = "1"; // subject가 memberId로 들어가므로
+        String token = JwtFactory.builder()
+                .subject(userId)
+                .claims(Map.of("id", 1L, "role", "USER"))
+                .build()
+                .createToken(jwtProperties);
+
+        // when
+        Authentication authentication = tokenProvider.getAuthentication(token);
+
+        // then
+        assertThat(((UserDetails) authentication.getPrincipal()).getUsername()).isEqualTo(userId);
+    }
+
+    @DisplayName("getMemberId(): 토큰으로 멤버 ID를 가져올 수 있다.")
+    @Test
+    void getUserId() {
+        // given
+        Long memberId = 1L;
+        String token = JwtFactory.builder()
+                .claims(Map.of("id", memberId, "role", "USER"))
+                .build()
+                .createToken(jwtProperties);
+
+        // when
+        Long extractedId = tokenProvider.getMemberId(token);
+
+        // then
+        assertThat(extractedId).isEqualTo(memberId);
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #22 

## 💜 작업 내용

- [x] JWT 토큰 인증/인가 구현 
->TokenService, refreshTokenRepository, JwtProperties, JwtTokenProvider, RefreshToken, TokenAuthenticationFilter, RefreshTokenRepository, CreateAccessTokenRequest, CreateAccessTokenResponse, MemberDetails, JwtFactory 
- [x] JWT 토큰 인증/인가 테스트 코드 작
-> TokenApiControllerTest, TokenProviderTest 
- [x] Swagger 세팅
-> SwaggerConfig
- [x] SpringSecurity 세팅
-> JwtAccessDeniedHandler, JwtAuthenticationEntryPoint, SecurityConfig , SecurityConfigProperties, application.yml
- [x] 토큰 재발급 api 및 테스트용 api 구현 
->TokenApiController, TestTokenApiController  
- [x] 토큰 관련 에러코드 추가
-> ErrorCode 
- [x] Member 도메인 상에 Role 속성 추가, Role enum 추가
-> Role

## ✅ PR Point

### JWT 토큰 인증/인가 구현
1. application.yml 시크릿 키 추가
```
jwt:
  secretKey: ${JWT_SECRET_KEY}
```
2. 해당 값들을 변수로 접근하는 데 사용한 JwtProperties 클래스
```
@Getter
@Setter
@Component
@ConfigurationProperties(prefix = "jwt") // 자바 클래스에 프로퍼티 값을 가져와서 사용하는 annotation
public class JwtProperties {
    private String secretKey;
}
```
3. 토큰을 생성하고 올바른 토큰인지 유효성 검사를 하고 토큰에서 필요한 정보를 가져오는 TokenProvider 클래스
```
@Service
@RequiredArgsConstructor
public class JwtTokenProvider {
    private final JwtProperties jwtProperties;

    public String generateToken(Member member, Duration expiredAt) {
        Date now = new Date();
        return makeToken(new Date(now.getTime() + expiredAt.toMillis()), member);
    }
    /**
     * JWT 토큰을 생성하는 메서드이다.
     * @param expiry 토큰의 만료 시간
     * @param member 회원 정보
     * @return 생성된 토큰
     */
    private String makeToken(Date expiry, Member member) {
        Date now = new Date();

        return Jwts.builder()
                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) //헤더 타입 : jwt
                .setIssuedAt(now)
                .setExpiration(expiry)
                .setSubject(String.valueOf(member.getMemberId()))
                .claim("id", member.getMemberId())
                .claim("role", member.getRole().name())
                // 서명 : 시크릿 키와 함께 해시값을 hs256 방식으로 암호화
                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
                .compact();
    }

    public boolean validToken(String token) {
        try{
            Jwts.parser()
                    .setSigningKey(jwtProperties.getSecretKey())
                    .parseClaimsJws(token);
            return true;
        } catch (Exception e) {
            return false;
        }
    }
    // 토큰 기반으로 인증 정보를 가져오는 메서드
    public Authentication getAuthentication(String token) {
        Claims claims = getClaims(token);
        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));

        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
    }

    // 토큰 기반으로 유저 id를 가져오는 메서드
    public Long getMemberId(String token) {
        Claims claims = getClaims(token);
        return claims.get("id", Long.class);
    }
,,,,


}
```
-> 여기까지 테스트 코드를 `**TokenProviderTest** `상에 작성해두었습니다.

### refresh token도메인 구현
1. `RefreshToken `엔티티 구현
2. `RefreshTokenRepository `구현
3. `TokenAuthenticationFilter `구현
유효 토큰일 시 security context holder에 인증 정보를 저장
![image](https://github.com/user-attachments/assets/38913de2-3c2c-478f-bccc-289881dee778)
```
public class TokenAuthenticationFilter extends OncePerRequestFilter {
    ,,,,

    @Override
    protected void doFilterInternal(
            HttpServletRequest request,
            HttpServletResponse response,
            FilterChain filterChain) throws ServletException, IOException{
        // 요청 헤더의 authorization 키의 값 조회
        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
        // 가져온 값에서 접두사 제거
        String token = getAccessToken(authorizationHeader);
        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
        if (token != null && tokenProvider.validToken(token)) {
            Authentication auth = tokenProvider.getAuthentication(token);

            SecurityContextHolder.getContext().setAuthentication(auth);
        }
        filterChain.doFilter(request, response);
    }

    private String getAccessToken(String authorizationHeader) {
        if(authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
            return authorizationHeader.substring(TOKEN_PREFIX.length());
        }
        return null;
    }
}
```
### 토큰 API 구현
1. MemberService에 `findById`(멤버 id로 유저를 검색해서 전달하는 메서드) 구현
2. RefreshTokenService에서 전달받은 refresh token으로 refresh token 객체를 검색해서 전달하는 `findByRefreshToken `메서드 구현
```
  public RefreshToken findByRefreshToken(String refreshToken) {
      return refreshTokenRepository.findByRefreshToken(refreshToken)
              .orElseThrow(() -> new FlexrateException(ErrorCode.INVALID_REFRESH_TOKEN));
  }
```
3. `CreateAccessTokenRqeust / Response`, `TokenApiController `구현, 이것으로 리프레쉬 토큰 기반으로 새로운 토큰 발급
-> 여기까지 테스트 코드는 `**TokenApiControllerTest** `에 작성해두었습니다

**그럼 앞으로 인증인가는 어떻게 처리받으면 되나요?**
1. 컨트롤러 상에 아래 메서드를 구현해주자
```
  private Member getMember(Principal principal) {
      return memberService.findById(Long.parseLong(principal.getName()));
  }
```
2. 아래 메서드를 이용해주자
예시 코드
```
    public ResponseEntity<?> createEssentialProfile(@RequestBody EssentialProfileCreateRequest request, Principal principal) {
        Member member = getMember(principal);

        memberService.createEssentialProfile(request, member);

        return new ResponseEntity<>(HttpStatus.OK);
    }
```
### Swagger 세팅
1. JWT 인증 적용
- `@SecurityScheme` 어노테이션으로 Swagger UI에서 JWT 토큰을 입력할 수 있도록 설정됨.
- 전역적으로 Bearer Authentication을 사용하는 API 보안 요구 사항 명시됨 (`@OpenAPIDefinition`).
3. 전역 에러 응답 정의
- `GlobalOpenApiCustomizer`를 통해 모든 API operation에 다음 기본 에러 응답 추가:
 - 400: 잘못된 요청 (필드 누락, 형식 오류 등)
 - 401: 인증 실패 (토큰 없음 또는 만료)
 - 500: 서버 내부 오류
- 각 API 마다 반복 정의하지 않아도 자동 적용됨.

swagger를 통해 jwt 인증/인가 테스트 하는 방법입니다

1. 아래 3개의 api는 현재 로그인이 없어 임의의 더미 데이터로 테스트할 수 있게끔 만들어둔 api입니다
![image](https://github.com/user-attachments/assets/cf21cd1d-5845-4797-84a8-553fe751dffb)
3. 마지막 임의 토큰 발급 api를 통해 발급 받은 액세스 토큰을 오른 상단의 authorize에 기입해주시고 저장해줍시다
![image](https://github.com/user-attachments/assets/73f61171-4c81-4d58-a047-0ac71069e1de)
![image](https://github.com/user-attachments/assets/1033ff9b-ae72-46d4-8d43-8e8f59febe33)
![image](https://github.com/user-attachments/assets/cea0da79-a182-412d-8a6d-2e0aab28b603)
4. 나머지 2개의 api를 즐기시면 됩니다
![image](https://github.com/user-attachments/assets/8ccc82eb-2479-4abb-9c14-511cbe03a9b4)

### SecurityConfig 세팅

1. JWT 기반 인증 체계 구축
- 모든 요청에 대해 커스텀 JWT 필터(`TokenAuthenticationFilter`)를 `UsernamePasswordAuthenticationFilter `앞에 등록해 토큰을 인증 처리
- 인증되지 않은 요청이나 권한이 부족한 요청에 대해 `JwtAuthenticationEntryPoint`와 `JwtAccessDeniedHandler`를 통해 일관된 예외 처리
3. CORS 정책 설정
- `allowedOrigins`, `allowedMethods`, `allowedHeaders`, `exposedHeaders`, `credentials `등 `SecurityConfigProperties`에서 주입받아 명시적으로 등록.
- 다양한 프론트엔드 클라이언트 환경에서 안전하게 접근할 수 있도록 CORS 유연성 확보.
4. 세션 비활성화
- JWT 사용으로 인해 STATELESS 세션 관리 정책 설정. 세션 저장 없이 인증 정보를 유지.
5. 보안 경로 설정
-` /api/auth/**, /swagger-ui/**, /v3/api-docs/** `경로는 인증 없이 접근 가능.
- 그 외 모든 요청은 인증 필요.
6. Spring Security 최신 방식 적용
- HttpSecurity DSL 방식(lambda)을 적용해 가독성과 유지보수성 향상.
- `@EnableWebSecurity` 및 명확한 SecurityFilterChain bean 등록으로 Spring Security 6.x 호환성 확보.