### PR TITLE
feat: 회원가입 등록 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -24,4 +25,16 @@ public class SecurityConfig {
         // JWT 인증 필터 추가 필요
         return http.build();
     }
+
+    /*
+     * 비밀번호를 암호화하기 위한 빈 등록
+     * @return BCryptPasswordEncoder 인스턴스
+     * @since 2025.04.27
+     * @author 윤영찬
+     */
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/api/SignUpController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/SignUpController.java
@@ -1,0 +1,45 @@
+package com.flexrate.flexrate_back.member.api;
+
+
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.dto.SignupRequestDTO;
+import com.flexrate.flexrate_back.member.dto.SignupResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/*
+ * 회원가입 로그인 API 컨트롤러
+ * @since 2025.04.28
+ * @author 윤영찬
+ */
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class SignUpController {
+
+    private final MemberService memberService;
+
+    /*
+     * 회원가입
+     * @param signupDTO 데이터
+     * @return 생성된 회원 ID, 이메일 (201 Created)
+     * @throws FlexrateException 유효성 검사 또는 중복 등 오류 발생 시
+     * @since 2025.04.28
+     */
+    @Operation(
+            summary = "회원가입",
+            description = "사용자로부터 이메일, 비밀번호, 이름 등의 정보를 입력받아 회원을 등록합니다. " +
+                    "이메일 중복 여부와 입력값의 유효성을 검사합니다.",
+            tags = { "Auth Controller" }
+    )
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseDTO> signup(
+            @RequestBody @Valid SignupRequestDTO dto) {
+
+        return ResponseEntity.status(201)
+                .body(memberService.registerMember(dto));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -1,0 +1,67 @@
+package com.flexrate.flexrate_back.member.application;
+
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.member.dto.SignupRequestDTO;
+import com.flexrate.flexrate_back.member.dto.SignupResponseDTO;
+import com.flexrate.flexrate_back.member.enums.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    /*
+     * 회원가입 중복 이메일을 체크하고, 회원을 등록한 후, 생성된 회원 정보를 응답
+     * @since 2025.05.03
+     * @author 윤영찬
+     * */
+
+    public SignupResponseDTO registerMember(SignupRequestDTO signupDTO) {
+        if (memberRepository.existsByEmail(signupDTO.email())) {
+            throw new FlexrateException(ErrorCode.EMAIL_ALREADY_REGISTERED);
+        }
+
+        String rawPwd = signupDTO.password();
+        String hashedPwd = passwordEncoder.encode(rawPwd);
+
+
+        ConsumptionType consumptionType;
+        ConsumeGoal consumeGoal;
+        Sex sex = Sex.valueOf(signupDTO.sex());
+
+        try {
+            consumptionType = signupDTO.consumptionType();
+            consumeGoal = signupDTO.consumeGoal();
+        } catch (IllegalArgumentException e) {
+            throw new FlexrateException(ErrorCode.VALIDATION_ERROR);
+        }
+
+        Member member = Member.builder()
+                .email(signupDTO.email())
+                .passwordHash(hashedPwd)
+                .name(signupDTO.name())
+                .sex(sex)
+                .birthDate(signupDTO.birthDate())
+                .status(MemberStatus.ACTIVE)
+                .consumptionType(consumptionType)
+                .consumeGoal(consumeGoal)
+                .role(Role.MEMBER)
+                .build();
+
+        Member saved = memberRepository.save(member);
+
+        return SignupResponseDTO.builder()
+                .userId(saved.getMemberId())
+                .email(saved.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
@@ -7,12 +7,14 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "Member")
 @Getter
 @NoArgsConstructor
@@ -26,7 +28,7 @@ public class Member {
     @Column(nullable = false, length = 50)
     private String email;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false)
     private String passwordHash;
 
     private LocalDateTime passwordLastChangedAt;
@@ -40,6 +42,11 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Sex sex;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
 
     private LocalDate birthDate;
 

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberRepository.java
@@ -4,5 +4,5 @@ import com.flexrate.flexrate_back.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    // 기본 CRUD 메서드 제공
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/SignupRequestDTO.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/SignupRequestDTO.java
@@ -1,0 +1,47 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.flexrate.flexrate_back.member.enums.ConsumeGoal;
+import com.flexrate.flexrate_back.member.enums.ConsumptionType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+/*
+ * 회원 가입 시 입력받는 사용자 검증 전달 DTO
+ * @since 2025.05.02
+ * @author 윤영찬
+ * */
+
+@Builder
+public record SignupRequestDTO(
+
+        @Email(message = "유효한 이메일을 입력해 주세요.")
+        @NotBlank(message = "이메일은 필수 항목입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 항목입니다.")
+        String password,
+
+        @NotBlank(message = "성별은 필수 항목입니다.")
+        String sex,
+
+        @NotBlank(message = "이름은 필수 항목입니다.")
+        String name,
+
+        @NotNull(message = "생년월일은 필수 항목입니다.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate birthDate,
+
+        @NotNull(message = "소비성향은 필수 항목입니다.")
+        @JsonProperty("consumption_type")
+        ConsumptionType consumptionType,
+
+        @NotNull(message = "소비 목표는 필수 항목입니다.")
+        @JsonProperty("consume_goal")
+        ConsumeGoal consumeGoal
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/SignupResponseDTO.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/SignupResponseDTO.java
@@ -1,0 +1,14 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import lombok.Builder;
+
+/*
+ * 회원가입 성공 시 반환하는 DTO
+ * @since 2025.04.28
+ * @author 윤영찬
+ */
+@Builder
+public record SignupResponseDTO (
+        Long userId,
+        String email
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/enums/Role.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/enums/Role.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.member.enums;
+
+public enum Role {
+    ADMIN,
+    MEMBER;
+
+    public String getAuthority() {
+        return "ROLE_" + this.name();
+    }
+}

--- a/src/test/java/com/flexrate/flexrate_back/member/application/MemberServiceTest.java
+++ b/src/test/java/com/flexrate/flexrate_back/member/application/MemberServiceTest.java
@@ -1,0 +1,102 @@
+package com.flexrate.flexrate_back.member.application;
+
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.dto.SignupRequestDTO;
+import com.flexrate.flexrate_back.member.dto.SignupResponseDTO;
+import com.flexrate.flexrate_back.member.enums.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import java.time.LocalDate;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/*
+ * DB 저장, 응답 DTO 확인
+ * 중복 이메일 시 예외 발생 여부 테스트
+ * @since 2025.05.02
+ * @author 윤영찬
+ * */
+
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testRegisterMemberSuccessfully() {
+        // Given
+        SignupRequestDTO signupRequestDTO = new SignupRequestDTO(
+                "user@naver.com",
+                "password123",
+                "MALE",
+                "yeongchan",
+                LocalDate.of(2000, 1, 1),
+                ConsumptionType.PRACTICAL,
+                ConsumeGoal.HAS_HOUSING_SAVING
+        );
+
+        SignupResponseDTO expectedResponseDTO = new SignupResponseDTO(1L, "user@naver.com");
+
+        when(memberRepository.existsByEmail(signupRequestDTO.email())).thenReturn(false);
+        when(passwordEncoder.encode(signupRequestDTO.password())).thenReturn("hashedPassword");
+
+        when(memberRepository.save(any())).thenReturn(
+                Member.builder()
+                        .memberId(1L)
+                        .email("user@naver.com")
+                        .passwordHash("hashedPassword")
+                        .name("yeongchan")
+                        .sex(Sex.MALE)
+                        .role(Role.MEMBER)
+                        .birthDate(LocalDate.of(2000, 1, 1))
+                        .status(MemberStatus.ACTIVE)
+                        .consumptionType(ConsumptionType.PRACTICAL)
+                        .consumeGoal(ConsumeGoal.ONLY_PUBLIC_TRANSPORT)
+                        .build()
+        );
+        // When
+        SignupResponseDTO result = memberService.registerMember(signupRequestDTO);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1L, result.userId());
+        assertEquals("user@naver.com", result.email());
+    }
+
+    @Test
+    void testRegisterMemberWhenEmailAlreadyRegistered() {
+        // Given
+        SignupRequestDTO signupRequestDTO = new SignupRequestDTO(
+                "user@naver.com",
+                "password123",
+                "MALE",
+                "yeongchan",
+                LocalDate.of(2000, 1, 1),
+                ConsumptionType.PRACTICAL,
+                ConsumeGoal.HAS_HOUSING_SAVING
+        );
+
+        when(memberRepository.existsByEmail(signupRequestDTO.email())).thenReturn(true);
+
+        // When & Then
+        assertThrows(FlexrateException.class, () -> memberService.registerMember(signupRequestDTO));
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #31 

## 💜 작업 내용

- [x] SignUpController API 엔드포인트 /api/auth/signup 구현
- [x] SignupMemberService를 통해 회원 등록 처리
- [x] 회원 DB 정보에 저장 후 성공적으로 반환
- [x] 회원가입 테스트 코드 작성

## ✅ PR Point
- signupDTO의 값이 적절히 전달되고, 필드 예외 처리가 잘 동작하는가?
- Service 코드에 FlexrateException을 통해 처리되는 예외 코드랑 메시지가 잘 작성했는가?

## 😡 Trouble Shooting
- password 컬럼에 먼저 평문값을 입력 후 password_hash에 암호화 처리가 되어 MySQL DB에 저장
- Bcrypt로 처리되는 password_hash에 먼저 값을 넣어버려서 401코드 발생
- 명세서와 엔터티 필드 재확인 후 해결
- 프론트에서 보내는 JSON 필드명이 Java의 필드명과 다를 경우 매핑되지 않거나 Enum 값이 null 처리 문제
- 요청 DTO에 애노테이션으로 명시하여 프론트쪽에 JSON 필드와 매핑

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/user-attachments/assets/2521b023-6df8-486a-af28-a2f0094067eb)

![image](https://github.com/user-attachments/assets/2bb0b874-bc99-4461-9577-6166a93b1fe7)

MySQL

![image](https://github.com/user-attachments/assets/26820681-10e9-4b4e-bb9f-9cdbd07bb256)
