### PR TITLE
fix: 관리자용 사용자 정보 상세 조회 API 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -143,7 +143,7 @@ public class MemberAdminService {
 
         LoanApplication app = memberQueryRepository.findLatestLoanApplication(memberId);
         Long tsCount = memberQueryRepository.countLoanTransactions(memberId);
-        Double interestRate = memberQueryRepository.findLatestInterestRate(memberId);
+        float interestRate = memberQueryRepository.findLatestInterestRate(memberId);
 
         // 남은 대출 기간 조회
         LocalDate now = LocalDate.now();
@@ -153,7 +153,7 @@ public class MemberAdminService {
         int leftMonths = period.getYears() * 12 + period.getMonths();
 
         // 월 상환액
-        double monthlyInterestRate = interestRate / 12 / 100;
+        float monthlyInterestRate = interestRate / 12 / 100;
         double principal = app.getRemainAmount();
         double monthlyPaymentRaw = principal *
                 (monthlyInterestRate * Math.pow(1 + monthlyInterestRate, leftMonths)) /

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepository.java
@@ -15,5 +15,5 @@ public interface MemberQueryRepository {
 
     LoanApplication findLatestLoanApplication(Long memberId);
     Long countLoanTransactions(Long memberId);
-    Double findLatestInterestRate(Long memberId);
+    Float findLatestInterestRate(Long memberId);
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -89,17 +89,15 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
     }
 
     @Override
-    public Double findLatestInterestRate(Long memberId) {
+    public Float findLatestInterestRate(Long memberId) {
         QInterest interest = QInterest.interest;
-        QLoanProduct loanProduct = QLoanProduct.loanProduct;
         QLoanApplication loanApplication = QLoanApplication.loanApplication;
         QMember member = QMember.member;
 
         return queryFactory
                 .select(interest.interestRate)
                 .from(interest)
-                .join(interest.loanProduct, loanProduct)
-                .join(loanProduct.application, loanApplication)
+                .join(interest.loanApplication, loanApplication)
                 .join(loanApplication.member, member)
                 .where(member.memberId.eq(memberId))
                 .orderBy(interest.interestDate.desc())

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberDetailResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberDetailResponse.java
@@ -14,7 +14,7 @@ public record MemberDetailResponse(
         Integer loanTransactionCount,
         String consumptionType,
         String consumeGoal,
-        Double interestRate,
+        Float interestRate,
         Integer creditScore,
         Integer totalPayment,
         String paymentDue,


### PR DESCRIPTION
## 🔥 Related Issues

- close #47 

## 💜 작업 내용

- [x] MemberAdminService 및 MemberQueryRepositoryImpl에서 interest 관련 로직 수정
- [x] MemberDetailResponse의 interestRate를 double에서 float로 변경

## ✅ PR Point

- interest에서 product_id가 삭제되고 application_id로 loan_application과 연결되었는데 해당 부분이 코드에 적용되지 않아 MemberQueryRepositoryImpl에서 loan_product를 join하던 로직을 삭제 후 loan_application과 join되도록 수정
- interest의 interestRate가 double에서 float로 변경됨에 따라 response와 MemberAdminService에서 double로 되어있던 부분을 전부 float로 수정

## 😡 Trouble Shooting

- 로직은 수정이 되었으나 sql 쪽에서 기존 더미데이터를 사용하고 있어 interest에 application_id 값이 들어가지 않아 null 오류 발생. interest 테이블에서 product_id column을 제거하고 application_id 값을 다시 넣어주었습니다.
- 또한 기존 product 테이블에서는 terms column이 String이었는데 Integer로 변경됨에 따라 해당 값 또한 update로 변경해주었습니다.

## ☀ 스크린샷 / GIF / 화면 녹화

Postman을 통해, 오류 이전처럼 제대로 출력되는 것을 확인
![image](https://github.com/user-attachments/assets/a380ec0f-6299-4b75-892c-363490855c12)


