### PR TITLE
fix: [공통] 관리자 권한 검증 로직 추가

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtTokenProvider.java
@@ -77,10 +77,4 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
     }
-
-    // 토큰 기반으로 유저 role 반환
-    public String getRole(String token) {
-        Claims claims = getClaims(token);
-        return claims.get("role", String.class);
-    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/jwt/JwtTokenProvider.java
@@ -77,4 +77,10 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
+    // 토큰 기반으로 유저 role 반환
+    public String getRole(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("role", String.class);
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -18,6 +18,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 
+import java.security.Principal;
+
 @RestController
 @RequestMapping("/api/admin/loans")
 @RequiredArgsConstructor
@@ -27,7 +29,6 @@ public class LoanAdminController {
 
     /**
      * 대출 거래 내역 목록 조회
-     * @param authHeader 인증 토큰
      * @param memberId 사용자 ID
      * @param page 페이지 번호
      * @param size 페이지 크기
@@ -38,7 +39,6 @@ public class LoanAdminController {
      */
     @Operation(summary = "대출 거래 내역 목록 조회", description = "관리자가 특정 사용자의 대출 거래 내역을 조회합니다.",
             parameters = {
-                @Parameter(name = "Authorization", description = "관리자 인증 토큰", required = true),
                 @Parameter(name = "memberId", description = "사용자 ID", required = true),
                 @Parameter(name = "page", description = "페이지 번호", required = false),
                 @Parameter(name = "size", description = "페이지 크기", required = false),
@@ -50,14 +50,14 @@ public class LoanAdminController {
             })
     @GetMapping("/members/{memberId}/transactions")
     public ResponseEntity<TransactionHistoryResponse> getTransactionHistory(
-            @RequestHeader("Authorization") String authHeader,
             @PathVariable("memberId") Long memberId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "date") String sortBy
+            @RequestParam(defaultValue = "date") String sortBy,
+            Principal principal
     ) {
         // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(authHeader)) {
+        if (!adminAuthChecker.isAdmin(principal)) {
             throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
         }
 
@@ -75,7 +75,6 @@ public class LoanAdminController {
     @Operation(
             summary = "대출 상태 변경", description = "관리자가 대출 신청의 상태를 변경합니다.",
             parameters = {
-                    @Parameter(name = "Authorization", description = "관리자 인증 토큰", required = true),
                     @Parameter(name = "loanApplicationId", description = "대출 신청 ID", required = true),
                     @Parameter(name = "request", description = "변경할 대출 상태 및 사유", required = true)
             },
@@ -86,12 +85,12 @@ public class LoanAdminController {
             })
     @PatchMapping("/{loanApplicationId}/status")
     public ResponseEntity<LoanApplicationStatusUpdateResponse> patchLoanApplicationStatus(
-            @RequestHeader("Authorization") String authHeader,
             @PathVariable("loanApplicationId") Long loanApplicationId,
-            @Valid @RequestBody LoanApplicationStatusUpdateRequest request
+            @Valid @RequestBody LoanApplicationStatusUpdateRequest request,
+            Principal principal
     ) {
         // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(authHeader)) {
+        if (!adminAuthChecker.isAdmin(principal)) {
             throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
         }
 

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -45,15 +45,9 @@ public class LoanAdminService {
             int size,
             String sortBy
     ) {
-        // A007 관리자 인증 체크
-//        if (!adminAuthChecker.isAdmin(adminToken)) {
-//            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
-//        }
-
         // U001 유저 존재 여부 체크
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
-
 
         // 기본 정렬 occurredAt 내림차순
         Sort sort = sortBy != null

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 
+import java.security.Principal;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/members")
@@ -24,24 +26,22 @@ public class MemberAdminController {
 
     /**
      * 관리자 권한으로 회원 목록 조회
-     * @param authHeader 인증 토큰
      * @param request 회원 검색 요청
      * @return 회원 검색 결과
      * @since 2025.04.26
      * @author 권민지
      */
     @Operation(summary = "관리자 권한으로 회원 목록 조회", description = "관리자가 회원 목록을 검색 조건에 따라 조회합니다.",
-            parameters = {@Parameter(name = "request", description = "회원 검색 요청(모든 인자 null 가능)", required = true),
-                          @Parameter(name = "X-Admin-Token", description = "관리자 인증 토큰", required = true)},
+            parameters = {@Parameter(name = "request", description = "회원 검색 요청(모든 인자 null 가능)", required = true)},
             responses = {@ApiResponse(responseCode = "200", description = "회원 검색 결과 반환"),
                          @ApiResponse(responseCode = "400", description = "관리자 인증 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A007\", \"message\": \"관리자 권한이 필요합니다.\"}"))),})
     @GetMapping("/search")
     public ResponseEntity<MemberSearchResponse> searchMembers(
-            @RequestHeader("Authorization") String authHeader,
-            @Valid MemberSearchRequest request
+            @Valid MemberSearchRequest request,
+            Principal principal
     ) {
         // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(authHeader)) {
+        if (!adminAuthChecker.isAdmin(principal)) {
             throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
         }
 
@@ -50,7 +50,6 @@ public class MemberAdminController {
 
     /**
      * 관리자 권한으로 회원 정보 수정
-     * @param authHeader 인증 토큰
      * @param request 회원 정보 수정 요청
      * @return 회원 정보 수정 결과
      * @since 2025.04.26
@@ -58,8 +57,7 @@ public class MemberAdminController {
      */
     @Operation(summary = "관리자 권한으로 회원 정보 수정", description = "관리자가 회원 id를 통해 특정 회원의 정보를 수정합니다.",
     parameters = {
-            @Parameter(name = "memberId", description = "수정할 memberId", required = true),
-            @Parameter(name = "X-Admin-Token", description = "관리자 인증 토큰", required = true)},
+            @Parameter(name = "memberId", description = "수정할 memberId", required = true)},
             responses = {
                     @ApiResponse(responseCode = "200", description = "회원 정보 수정 결과 반환"),
                     @ApiResponse(responseCode = "400", description = "관리자 인증 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A007\", \"message\": \"관리자 권한이 필요합니다.\"}"))),
@@ -70,12 +68,12 @@ public class MemberAdminController {
             })
     @PatchMapping("/{memberId}")
     public ResponseEntity<PatchMemberResponse> patchMember(
-            @RequestHeader("Authorization") String authHeader,
             @PathVariable Long memberId,
-            @Valid @RequestBody PatchMemberRequest request
+            @Valid @RequestBody PatchMemberRequest request,
+            Principal principal
     ) {
         // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(authHeader)) {
+        if (!adminAuthChecker.isAdmin(principal)) {
             throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
         }
 
@@ -84,7 +82,6 @@ public class MemberAdminController {
 
     /**
      * 관리자 권한으로 회원 정보 상세 조회
-     * @param authHeader 인증 토큰
      * @param memberId 조회할 회원 Id
      * @return 회원 상세 정보 조회 결과
      * @since 2025.04.29
@@ -93,8 +90,7 @@ public class MemberAdminController {
 
     @Operation(summary = "관리자 권한으로 회원 정보 상세 조회", description = "관리자가 회원 id를 통해 특정 회원의 정보를 상세 조회합니다.",
             parameters = {
-                    @Parameter(name = "memberId", description = "조회할 memberId", required = true),
-                    @Parameter(name = "X-Admin-Token", description = "관리자 인증 토큰", required = true)},
+                    @Parameter(name = "memberId", description = "조회할 memberId", required = true)},
             responses = {
                     @ApiResponse(responseCode = "200", description = "회원 정보 조회 결과 반환"),
                     @ApiResponse(responseCode = "400", description = "관리자 인증 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A007\", \"message\": \"관리자 권한이 필요합니다.\"}"))),
@@ -106,11 +102,11 @@ public class MemberAdminController {
     @GetMapping("/{memberId}")
     // @PreAuthorize("hasRole('ADMIN')") - 우선은 adminToken으로 테스트
     public ResponseEntity<MemberDetailResponse> getMemberDetail(
-            @RequestHeader("Authorization") String authHeader,
-            @PathVariable Long memberId
+            @PathVariable Long memberId,
+            Principal principal
     ) {
         // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(authHeader)) {
+        if (!adminAuthChecker.isAdmin(principal)) {
             throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
         }
 

--- a/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthChecker.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthChecker.java
@@ -1,5 +1,5 @@
 package com.flexrate.flexrate_back.member.application;
 
 public interface AdminAuthChecker {
-    boolean isAdmin(String adminToken);
+    boolean isAdmin(String token);
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthChecker.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthChecker.java
@@ -1,5 +1,7 @@
 package com.flexrate.flexrate_back.member.application;
 
+import java.security.Principal;
+
 public interface AdminAuthChecker {
-    boolean isAdmin(String token);
+    boolean isAdmin(Principal principal);
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthCheckerImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthCheckerImpl.java
@@ -1,15 +1,31 @@
 package com.flexrate.flexrate_back.member.application;
 
+import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
+import com.flexrate.flexrate_back.member.enums.Role;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class AdminAuthCheckerImpl implements AdminAuthChecker {
-
-    // 추후 변경
-    private static final String ADMIN_TOKEN = "adminToken";
+    private final JwtTokenProvider tokenProvider;
 
     @Override
-    public boolean isAdmin(String adminToken) {
-        return ADMIN_TOKEN.equals(adminToken);
+    public boolean isAdmin(String token) {
+        if (token == null || token.isEmpty()) return false;
+
+        // Bearer 접두어 제거
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        // 토큰 유효성 검사
+        if (!tokenProvider.validToken(token)) {
+            return false;
+        }
+
+        // Role 추출 및 검사
+        String role = tokenProvider.getRole(token);
+        return Role.ADMIN.name().equals(role);
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthCheckerImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/AdminAuthCheckerImpl.java
@@ -1,31 +1,21 @@
 package com.flexrate.flexrate_back.member.application;
 
 import com.flexrate.flexrate_back.auth.domain.jwt.JwtTokenProvider;
+import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.security.Principal;
+
 @Component
 @RequiredArgsConstructor
 public class AdminAuthCheckerImpl implements AdminAuthChecker {
-    private final JwtTokenProvider tokenProvider;
+    private final MemberService memberService;
 
     @Override
-    public boolean isAdmin(String token) {
-        if (token == null || token.isEmpty()) return false;
-
-        // Bearer 접두어 제거
-        if (token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
-
-        // 토큰 유효성 검사
-        if (!tokenProvider.validToken(token)) {
-            return false;
-        }
-
-        // Role 추출 및 검사
-        String role = tokenProvider.getRole(token);
-        return Role.ADMIN.name().equals(role);
+    public boolean isAdmin(Principal principal) {
+        Member member = memberService.findById(Long.parseLong(principal.getName()));
+        return Role.ADMIN.equals(member.getRole());
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -28,23 +28,16 @@ public class MemberAdminService {
     private final MemberRepository memberRepository;
     private final MemberQueryRepository memberQueryRepository;
     private final MemberMapper memberMapper;
-    private final AdminAuthChecker adminAuthChecker;
 
     /**
      * 관리자 권한으로 회원 목록 조회
      * @param request 검색 조건
-     * @param adminToken 관리자 인증 토큰
      * @return MemberSearchResponse 회원 목록, 페이징 정보
      * @throws FlexrateException ErrorCode ADMIN_AUTH_REQUIRED 관리자 인증 필요
      * @since 2025.04.26
      * @author 권민지
      */
-    public MemberSearchResponse searchMembers(@Valid MemberSearchRequest request, String adminToken) {
-        // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(adminToken)) {
-            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
-        }
-
+    public MemberSearchResponse searchMembers(@Valid MemberSearchRequest request) {
         // 기본 정렬 createdAt 내림차순
         Sort sort = request.sortBy() != null
                 ? Sort.by(request.sortBy().name()).ascending()
@@ -74,7 +67,6 @@ public class MemberAdminService {
     /**
      * 관리자 권한으로 회원 정보 수정
      * @param request 수정할 회원 정보
-     * @param adminToken 관리자 인증 토큰
      * @return MemberSearchResponse 수정된 회원 정보
      * @throws FlexrateException ErrorCode ADMIN_AUTH_REQUIRED 관리자 인증 필요, USER_NOT_FOUND 사용자를 찾지 못함,
      * AUTH_REQUIRED_FIELD_MISSING 필수 입력값 누락
@@ -82,12 +74,7 @@ public class MemberAdminService {
      * @author 허연규
      */
     @Transactional
-    public PatchMemberResponse patchMember(Long memberId, @Valid PatchMemberRequest request, String adminToken) {
-        // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(adminToken)) {
-            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
-        }
-
+    public PatchMemberResponse patchMember(Long memberId, @Valid PatchMemberRequest request) {
         // U001 유저 존재 여부 체크
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
@@ -124,19 +111,13 @@ public class MemberAdminService {
     /**
      * 관리자 권한으로 회원 정보 상세 조회
      * @param memberId 조회할 회원 Id
-     * @param adminToken 관리자 인증 토큰
      * @return MemberDetailSearchResponse
      * @throws FlexrateException ErrorCode ADMIN_AUTH_REQUIRED 관리자 인증 필요, USER_NOT_FOUND 사용자를 찾지 못함
      * @since 2025.04.29
      * @author 허연규
      */
 
-    public MemberDetailResponse searchMemberDetail(Long memberId, String adminToken) {
-        // A007 관리자 인증 체크
-        if (!adminAuthChecker.isAdmin(adminToken)) {
-            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
-        }
-
+    public MemberDetailResponse searchMemberDetail(Long memberId) {
         // U001 유저 존재 여부 체크
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
## 🔥 Related Issues

- close #39 

## 💜 작업 내용

- [x] 기존 관리자 인증 방식을 JWT 역할 기반 인증으로 리팩토링
- [x] 컨트롤러에서 X-Admin-Token → Authorization 헤더로 교체
- [x] 서비스 계층의 인증 로직을 컨트롤러로 이동하여 책임 분리
- [x] 관리자 검증 공통 메서드 `isAdmin` 구현

## ✅ PR Point

- 관리자 검증 공통 메서드 `isAdmin`을 구현하였으니 검토해주시고, 앞으로 "관리자" 권한 검증이 필요할 경우, 해당 메서드를 사용해주시기 바랍니다.
```
     public boolean isAdmin(String token) {
        if (token == null || token.isEmpty()) return false;

        // Bearer 접두어 제거
        if (token.startsWith("Bearer ")) {
            token = token.substring(7);
        }

        // 토큰 유효성 검사
        if (!tokenProvider.validToken(token)) {
            return false;
        }

        // Role 추출 및 검사
        String role = tokenProvider.getRole(token);
        return Role.ADMIN.name().equals(role);
    }
```
- isAdmin 사용 방법
```
        // A007 관리자 인증 체크
        if (!adminAuthChecker.isAdmin(authHeader)) {
            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
        }
```
- ⭐ @HeoYeonGyu 제 로직 변경하면서 연규님 로직(관리자 API)까지 admin 메서드를 함께 통일하여 추가 및 개선하였으니, 확인 부탁드립니다!
- ⭐ @ryuseunghan role 기반 검증을 위해 JwtTokenProvider에 `getRole` 메서드를 추가하였으니 확인 부탁드립니다!
```
// 토큰 기반으로 유저 role 반환
    public String getRole(String token) {
        Claims claims = getClaims(token);
        return claims.get("role", String.class);
    }
```

## ☀ 스크린샷 / GIF / 화면 녹화

### 인증되지 않은 사용자(유효한 token이 아닐 경우)

<img width="1001" alt="인증되지 않은 사용자" src="https://github.com/user-attachments/assets/71b8b668-712d-402a-a46f-7a19ef47b0a6" />

### 유효한 사용자이지만, 관리자(Role.ADMIN)가 아닐 경우
<img width="988" alt="관리자 권한이 필요합니다" src="https://github.com/user-attachments/assets/35b30bbf-13d4-49b6-a0a5-14dca4cb70cb" />

### 관리자(Role.ADMIN) 토큰으로 정상 접근
<img width="1035" alt="정상 반환" src="https://github.com/user-attachments/assets/7058abcb-c00b-450f-9f4f-b5a02986cb15" />

## 📝 테스트 프로세스
1. 관리자 계정으로 JWT 토큰 발급
   - `/api/auth/generate-dev-token?memberId=100&role=ADMIN`
2. JWT 토큰으로 회원 목록 조회 요청
   - `/admin/members/search`
   - Headers에 `Authorization: Bearer {복사한 accessToken}` 추가