### PR TITLE
feature: 마이페이지 개인 정보 조회/수정 및 소비 타입별 목표 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfig.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",
+                                "/api/members/consume-goal/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     LOAN_PRODUCT_NOT_FOUND("L008", "대출 상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     LOAN_REQUEST_CONFLICT("L009", "대출 신청 요청이 제약 조건에 위배됩니다.", HttpStatus.BAD_REQUEST),
     LOAN_NOT_APPLIED("L010", "신청을 하지 않은 대출입니다.", HttpStatus.BAD_REQUEST),
+    LOAN_CONSUMPTION_TYPE_MISMATCH("L011", "소비 유형이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 인증/인가
     AUTH_REQUIRED_FIELD_MISSING("A000", "필수 입력값이 누락되었습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -1,0 +1,36 @@
+package com.flexrate.flexrate_back.member.api;
+
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.dto.MypageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+    private final MemberService memberService;
+
+    /**
+     * 마이페이지 조회
+     * @return 회원 정보(MypageResponse) - 이름, 이메일, 소비 목표, 소비 유형
+     * @since 2025.05.07
+     * @author 권민지
+     */
+    @Operation(summary = "로그인한 사용자의 마이페이지 조회",
+            description = "로그인한 사용자의 마이페이지 정보를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "사용자의 마이페이지 조회 결과 반환"),
+                         @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
+    @GetMapping("/mypage")
+    public ResponseEntity<MypageResponse> getMyPage(Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+        return ResponseEntity.ok(memberService.getMyPage(memberId));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -2,11 +2,13 @@ package com.flexrate.flexrate_back.member.api;
 
 import com.flexrate.flexrate_back.member.application.MemberService;
 import com.flexrate.flexrate_back.member.dto.MypageResponse;
+import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +34,22 @@ public class MemberController {
     public ResponseEntity<MypageResponse> getMyPage(Principal principal) {
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.getMyPage(memberId));
+    }
+
+    /**
+     * 마이페이지 정보 수정
+     * @param request 마이페이지 수정 요청
+     * @return 회원 정보(MypageResponse) - 이름, 이메일, 소비 목표, 소비 유형
+     * @since 2025.05.07
+     * @author 권민지
+     */
+    @Operation(summary = "로그인한 사용자의 마이페이지 정보 수정",
+            description = "로그인한 사용자의 마이페이지 정보를 수정합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "사용자의 마이페이지 수정 결과 반환"),
+                         @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
+    @PatchMapping("/mypage")
+    public ResponseEntity<MypageResponse> updateMyPage(MypageUpdateRequest request, Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+        return ResponseEntity.ok(memberService.updateMyPage(memberId, request));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -7,6 +7,7 @@ import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
 import com.flexrate.flexrate_back.member.enums.ConsumptionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,7 +48,10 @@ public class MemberController {
             responses = {@ApiResponse(responseCode = "200", description = "사용자의 마이페이지 수정 결과 반환"),
                          @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
     @PatchMapping("/mypage")
-    public ResponseEntity<MypageResponse> updateMyPage(MypageUpdateRequest request, Principal principal) {
+    public ResponseEntity<MypageResponse> updateMyPage(
+            @Valid @RequestBody MypageUpdateRequest request,
+            Principal principal
+    ) {
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.updateMyPage(memberId, request));
     }

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -1,16 +1,15 @@
 package com.flexrate.flexrate_back.member.api;
 
 import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.dto.ConsumeGoalResponse;
 import com.flexrate.flexrate_back.member.dto.MypageResponse;
 import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
+import com.flexrate.flexrate_back.member.enums.ConsumptionType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -51,5 +50,20 @@ public class MemberController {
     public ResponseEntity<MypageResponse> updateMyPage(MypageUpdateRequest request, Principal principal) {
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.updateMyPage(memberId, request));
+    }
+
+    /**
+     * 소비 유형별 소비 목표 반환
+     * @param consumptionType 소비 유형
+     * @return 소비 목표 list
+     * @since 2025.05.07
+     * @author 권민지
+     */
+    @Operation(summary = "소비 유형별 소비 목표 조회", description = "소비 유형에 따른 소비 목표를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "소비 목표 조회 결과 반환"),
+                         @ApiResponse(responseCode = "400", description = "잘못된 소비 유형입니다.")})
+    @GetMapping("/consume-goal/{consumptionType}")
+    public ResponseEntity<ConsumeGoalResponse> getConsumeGoal(@PathVariable("consumptionType") ConsumptionType consumptionType) {
+        return ResponseEntity.ok(memberService.getConsumeGoal(consumptionType));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -4,10 +4,7 @@ import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
-import com.flexrate.flexrate_back.member.dto.MypageResponse;
-import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
-import com.flexrate.flexrate_back.member.dto.SignupRequestDTO;
-import com.flexrate.flexrate_back.member.dto.SignupResponseDTO;
+import com.flexrate.flexrate_back.member.dto.*;
 import com.flexrate.flexrate_back.member.enums.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -122,6 +119,20 @@ public class MemberService {
                 .consumeGoal(member.getConsumeGoal())
                 .consumptionType(member.getConsumptionType())
                 .build();
+    }
+
+    /**
+     * 소비 유형별 소비 목표 반환
+     * @param consumptionType 소비 유형
+     * @return 소비 목표 list
+     * @since 2025.05.07
+     * @author 권민지
+     */
+    public ConsumeGoalResponse getConsumeGoal(ConsumptionType consumptionType) {
+        return ConsumeGoalResponse.builder()
+                .consumeGoals(ConsumeGoal.getConsumeGoalsByType(consumptionType))
+                .build();
+
     }
 }
 

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -4,6 +4,7 @@ import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.member.dto.MypageResponse;
 import com.flexrate.flexrate_back.member.dto.SignupRequestDTO;
 import com.flexrate.flexrate_back.member.dto.SignupResponseDTO;
 import com.flexrate.flexrate_back.member.enums.*;
@@ -68,6 +69,25 @@ public class MemberService {
     public Member findById(Long memberId) {
     return memberRepository.findById(memberId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 마이페이지 조회
+     * @param memberId 회원 ID
+     * @return 회원 정보(MypageResponse) - 이름, 이메일, 소비 목표, 소비 유형
+     * @since 2025.04.26
+     * @author 권민지
+     */
+    public MypageResponse getMyPage(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        return MypageResponse.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .consumeGoal(member.getConsumeGoal())
+                .consumptionType(member.getConsumptionType())
+                .build();
     }
 }
 

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -5,15 +5,18 @@ import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import com.flexrate.flexrate_back.member.dto.MypageResponse;
+import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
 import com.flexrate.flexrate_back.member.dto.SignupRequestDTO;
 import com.flexrate.flexrate_back.member.dto.SignupResponseDTO;
 import com.flexrate.flexrate_back.member.enums.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -75,12 +78,43 @@ public class MemberService {
      * 마이페이지 조회
      * @param memberId 회원 ID
      * @return 회원 정보(MypageResponse) - 이름, 이메일, 소비 목표, 소비 유형
-     * @since 2025.04.26
+     * @since 2025.05.07
      * @author 권민지
      */
     public MypageResponse getMyPage(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        return MypageResponse.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .consumeGoal(member.getConsumeGoal())
+                .consumptionType(member.getConsumptionType())
+                .build();
+    }
+
+    /**
+     * 마이페이지 정보 수정
+     * @param memberId 회원 ID
+     * @param request MypageUpdateRequest 요청 DTO (이메일, 소비 목표)
+     * @return 수정된 회원 정보(MypageResponse) - 이름, 이메일, 소비 목표, 소비 유형
+     * @since 2025.05.07
+     * @author 권민지
+     */
+    @Transactional
+    public MypageResponse updateMyPage(Long memberId, MypageUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        if (request.email() != null) member.updateEmail(request.email());
+        if (request.consumeGoal() != null) {
+            // L011 - 소비 목표가 소비 타입과 다르다면, 소비 목표를 변경할 수 없음
+            if (request.consumeGoal().getType() != member.getConsumptionType()) {
+                throw new FlexrateException(ErrorCode.LOAN_CONSUMPTION_TYPE_MISMATCH);
+            }
+
+            member.updateConsumeGoal(request.consumeGoal());
+        }
 
         return MypageResponse.builder()
                 .name(member.getName())

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
@@ -89,6 +89,8 @@ public class Member {
         this.name = name;
     }
 
+    public void updateEmail(String email) {this.email = email;}
+
     public void updateSex(Sex sex) {
         this.sex = sex;
     }
@@ -100,4 +102,6 @@ public class Member {
     public void updateMemberStatus(MemberStatus memberStatus) {
         this.status = memberStatus;
     }
+
+    public void updateConsumeGoal(ConsumeGoal consumeGoal) {this.consumeGoal = consumeGoal;}
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/ConsumeGoalResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/ConsumeGoalResponse.java
@@ -1,0 +1,17 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.member.enums.ConsumeGoal;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ConsumeGoalResponse (
+        List<ConsumeGoalSummary> consumeGoals
+) {
+    @Builder
+    public record ConsumeGoalSummary(
+            ConsumeGoal consumeGoal,
+            String description
+    ) {}
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MypageResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MypageResponse.java
@@ -1,0 +1,13 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.member.enums.ConsumeGoal;
+import com.flexrate.flexrate_back.member.enums.ConsumptionType;
+import lombok.Builder;
+
+@Builder
+public record MypageResponse(
+        String name,
+        String email,
+        ConsumeGoal consumeGoal,
+        ConsumptionType consumptionType
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MypageUpdateRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MypageUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import com.flexrate.flexrate_back.member.enums.ConsumeGoal;
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+
+@Builder
+public record MypageUpdateRequest (
+        @Email(message = "이메일 형식이 아닙니다.")
+        String email,
+        ConsumeGoal consumeGoal
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/enums/ConsumeGoal.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/enums/ConsumeGoal.java
@@ -1,7 +1,12 @@
 package com.flexrate.flexrate_back.member.enums;
 
+import com.flexrate.flexrate_back.member.dto.ConsumeGoalResponse.ConsumeGoalSummary;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor
@@ -28,4 +33,16 @@ public enum ConsumeGoal {
 
     private final String description;
     private final ConsumptionType type;
+
+    /**
+     * 특정 소비 유형에 해당하는 소비 목표 리스트 반환
+     * @param type 소비 유형
+     * @return 소비 목표 리스트(ConsumeGoal, description)
+     */
+    public static List<ConsumeGoalSummary> getConsumeGoalsByType(ConsumptionType type) {
+        return Arrays.stream(values())
+                .filter(goal -> goal.getType() == type)
+                .map(goal -> new ConsumeGoalSummary(goal, goal.getDescription()))
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #53 

## 💜 작업 내용

- [x] 마이페이지 개인정보 조회 api 구현
- [x] 마이페이지 개인정보 수정 api 구현
- [x] 소비 타입별 목표 리스트 조회 api 구현

## ✅ PR Point
- 마이페이지 수정 API의 경우, 인자는 email 또는 소비 목표 두 가지이며 필수값이 아닙니다.
- 소비 타입별 목표 조회 API는 인증이 필요하지 않습니다. (SecurityConfig에 url 추가)
- 에러코드(ErrorCode) 추가되었습니다.
```
LOAN_CONSUMPTION_TYPE_MISMATCH("L011", "소비 유형이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
```

## ☀ 스크린샷 / GIF / 화면 녹화
### 마이페이지 조회 API - 로그인하지 않고 요청하는 경우

<img width="300" alt="조회-로그인x" src="https://github.com/user-attachments/assets/be3b3244-b166-40fc-acc6-ab87ff58391c" />

### 마이페이지 조회 API - 정상 응답의 경우

<img width="1068" alt="조회-정상응답" src="https://github.com/user-attachments/assets/7fa84d36-5a0c-4527-87af-20c4a52ff04e" />

### 마이페이지 수정 API - 소비 유형 불일치의 경우
<img width="1077" alt="수정-소비유형불일치" src="https://github.com/user-attachments/assets/33dbc22b-d196-48ed-b0a3-ef6fd12cc363" />

### 마이페이지 수정 API - 정상 응답의 경우
<img width="1078" alt="수정-정상응답" src="https://github.com/user-attachments/assets/497f71f7-749c-4968-8142-cf2271e2eac3" />

### 소비 타입별 목표 리스트 조회 API - 정상 응답의 경우
<img width="545" alt="스크린샷 2025-05-07 17 45 35" src="https://github.com/user-attachments/assets/69d82145-2547-4aff-826f-63a33bc19712" />
