### PR TITLE
feature: 소비습관 리포트 조회 API 작업

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/FlexrateBackApplication.java
@@ -5,7 +5,9 @@ import com.flexrate.flexrate_back.common.config.SecurityConfigProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableConfigurationProperties({JwtProperties.class, SecurityConfigProperties.class})
 public class FlexrateBackApplication {

--- a/src/main/java/com/flexrate/flexrate_back/common/converter/YearMonthAttributeConverter.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/converter/YearMonthAttributeConverter.java
@@ -1,0 +1,23 @@
+package com.flexrate.flexrate_back.common.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+@Converter(autoApply = false)
+public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        return attribute != null ? attribute.format(FORMATTER) : null;
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+        return dbData != null ? YearMonth.parse(dbData, FORMATTER) : null;
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -27,6 +27,10 @@ public enum ErrorCode {
     LOAN_NOT_APPLIED("L010", "신청을 하지 않은 대출입니다.", HttpStatus.BAD_REQUEST),
     LOAN_CONSUMPTION_TYPE_MISMATCH("L011", "소비 유형이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
+    // 리포트
+    REPORT_MEMBER_OR_MONTH_NULL("R001", "member 또는 month는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    REPORT_ALREADY_EXISTS("R002", "해당 월의 소비습관 리포트가 이미 존재합니다.", HttpStatus.CONFLICT),
+
     // 금리
     NO_INTEREST("I001", "저장된 금리가 없습니다.", HttpStatus.NOT_FOUND),
     

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/UserFinancialData.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/UserFinancialData.java
@@ -1,5 +1,6 @@
 package com.flexrate.flexrate_back.financialdata.domain;
 
+import com.flexrate.flexrate_back.financialdata.enums.UserFinancialCategory;
 import com.flexrate.flexrate_back.financialdata.enums.UserFinancialDataType;
 import com.flexrate.flexrate_back.member.domain.Member;
 import jakarta.persistence.*;
@@ -26,6 +27,10 @@ public class UserFinancialData {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserFinancialDataType dataType;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private UserFinancialCategory category;
 
     @Column(nullable = false, precision = 12)
     private int value;

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepository.java
@@ -1,0 +1,11 @@
+package com.flexrate.flexrate_back.financialdata.domain.repository;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryRatioResponse;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public interface UserFinancialDataQueryRepository {
+    List<ConsumptionCategoryRatioResponse> findCategoryStatsWithRatio(Member member, YearMonth month);
+}

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.flexrate.flexrate_back.financialdata.domain.repository;
 
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.financialdata.domain.QUserFinancialData;
 import com.flexrate.flexrate_back.financialdata.enums.UserFinancialDataType;
 import com.flexrate.flexrate_back.member.domain.Member;
@@ -24,7 +26,7 @@ public class UserFinancialDataQueryRepositoryImpl implements UserFinancialDataQu
      * @param member 조회 대상 회원
      * @param month 조회할 월 (yyyy-MM)
      * @return 카테고리별 소비 금액과 비율 리스트
-     * @throws IllegalArgumentException member 또는 month가 null일 경우
+     * @throws FlexrateException REPORT_MEMBER_OR_MONTH_NULL member 또는 month가 null일 경우
      * @since 2025.05.08
      * @author 서채연
      */
@@ -33,7 +35,7 @@ public class UserFinancialDataQueryRepositoryImpl implements UserFinancialDataQu
         QUserFinancialData u = QUserFinancialData.userFinancialData;
 
         if (member == null || month == null) {
-            throw new IllegalArgumentException("member 또는 month는 null일 수 없습니다.");
+            throw new FlexrateException(ErrorCode.REPORT_MEMBER_OR_MONTH_NULL);
         }
 
         LocalDateTime start = month.atDay(1).atStartOfDay();

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.flexrate.flexrate_back.financialdata.domain.repository;
+
+import com.flexrate.flexrate_back.financialdata.domain.QUserFinancialData;
+import com.flexrate.flexrate_back.financialdata.enums.UserFinancialDataType;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryRatioResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserFinancialDataQueryRepositoryImpl implements UserFinancialDataQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ConsumptionCategoryRatioResponse> findCategoryStatsWithRatio(Member member, YearMonth month) {
+        QUserFinancialData u = QUserFinancialData.userFinancialData;
+
+        if (member == null || month == null) {
+            throw new IllegalArgumentException("member 또는 month는 null일 수 없습니다.");
+        }
+
+        LocalDateTime start = month.atDay(1).atStartOfDay();
+        LocalDateTime end = month.plusMonths(1).atDay(1).atStartOfDay();
+
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(u.member.memberId.eq(member.getMemberId()))
+                .and(u.dataType.eq(UserFinancialDataType.EXPENSE))
+                .and(u.collectedAt.goe(start))
+                .and(u.collectedAt.lt(end));
+
+        Integer totalAmount = queryFactory
+                .select(u.value.sum())
+                .from(u)
+                .where(builder)
+                .fetchOne();
+
+        if (totalAmount == null || totalAmount == 0) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(
+                        u.category.stringValue(),
+                        u.value.sum()
+                )
+                .from(u)
+                .where(builder)
+                .groupBy(u.category)
+                .fetch()
+                .stream()
+                .map(tuple -> {
+                    String category = tuple.get(0, String.class);
+                    Integer amount = tuple.get(1, Integer.class);
+                    double percentage = Math.round((amount * 1000.0 / totalAmount)) / 10.0;
+                    return new ConsumptionCategoryRatioResponse(category, amount, percentage);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataQueryRepositoryImpl.java
@@ -19,6 +19,15 @@ public class UserFinancialDataQueryRepositoryImpl implements UserFinancialDataQu
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 특정 회원의 특정 월 소비 데이터를 기준으로 카테고리별 소비 금액과 비율 계산
+     * @param member 조회 대상 회원
+     * @param month 조회할 월 (yyyy-MM)
+     * @return 카테고리별 소비 금액과 비율 리스트
+     * @throws IllegalArgumentException member 또는 month가 null일 경우
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Override
     public List<ConsumptionCategoryRatioResponse> findCategoryStatsWithRatio(Member member, YearMonth month) {
         QUserFinancialData u = QUserFinancialData.userFinancialData;

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/domain/repository/UserFinancialDataRepository.java
@@ -1,0 +1,6 @@
+package com.flexrate.flexrate_back.financialdata.domain.repository;
+
+import com.flexrate.flexrate_back.financialdata.domain.UserFinancialData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserFinancialDataRepository extends JpaRepository<UserFinancialData, Long>, UserFinancialDataQueryRepository {}

--- a/src/main/java/com/flexrate/flexrate_back/financialdata/enums/UserFinancialCategory.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/enums/UserFinancialCategory.java
@@ -1,0 +1,12 @@
+package com.flexrate.flexrate_back.financialdata.enums;
+
+public enum UserFinancialCategory {
+    FOOD,
+    LIVING,
+    LEISURE,
+    TRANSPORT,
+    COMMUNICATION,
+    EDUCATION,
+    HEALTH,
+    ETC,
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ConsumptionHabitReportController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ConsumptionHabitReportController.java
@@ -22,6 +22,14 @@ public class ConsumptionHabitReportController {
     private final ConsumptionHabitReportService reportService;
     private final MemberService memberService;
 
+    /**
+     * 사용자 본인의 소비 습관 리포트 조회 API
+     * @param principal 현재 로그인한 사용자 정보
+     * @param month 조회할 리포트 월 (yyyy-MM 형식, optional)
+     * @return 소비습관 리포트 목록 (단일 or 전체)
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Operation(summary = "소비 리포트 조회", description = "특정 월을 입력하면 해당 월 리포트를, 입력하지 않으면 전체 리포트를 반환합니다.")
     @GetMapping("/consumption-report")
     public List<ConsumptionHabitReportResponse> getMyReports(

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ConsumptionHabitReportController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ConsumptionHabitReportController.java
@@ -1,0 +1,48 @@
+package com.flexrate.flexrate_back.report.api;
+
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.application.ConsumptionHabitReportService;
+import com.flexrate.flexrate_back.report.dto.ConsumptionHabitReportResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.time.YearMonth;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ConsumptionHabitReportController {
+
+    private final ConsumptionHabitReportService reportService;
+    private final MemberService memberService;
+
+    @Operation(summary = "소비 리포트 조회", description = "특정 월을 입력하면 해당 월 리포트를, 입력하지 않으면 전체 리포트를 반환합니다.")
+    @GetMapping("/consumption-report")
+    public List<ConsumptionHabitReportResponse> getMyReports(
+            Principal principal,
+            @Parameter(description = "조회할 연월 (yyyy-MM)", example = "2025-05")
+            @RequestParam(value = "조회할 연월 (yyyy-MM)", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM") YearMonth month
+    ) {
+        Long memberId = Long.parseLong(principal.getName());
+        Member member = memberService.findById(memberId);
+
+        if (month != null) {
+            return reportService.getReport(member, month)
+                    .map(ConsumptionHabitReportResponse::from)
+                    .map(List::of)
+                    .orElse(List.of());
+        } else {
+            return reportService.getAllReportsByMember(member).stream()
+                    .map(ConsumptionHabitReportResponse::from)
+                    .toList();
+        }
+    }
+
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ConsumptionHabitReportController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ConsumptionHabitReportController.java
@@ -30,13 +30,18 @@ public class ConsumptionHabitReportController {
      * @since 2025.05.08
      * @author 서채연
      */
-    @Operation(summary = "소비 리포트 조회", description = "특정 월을 입력하면 해당 월 리포트를, 입력하지 않으면 전체 리포트를 반환합니다.")
+    @Operation(
+            summary = "소비 습관 개선 리포트 조회",
+            description = "특정 월을 입력하면 해당 월 리포트를, 입력하지 않으면 전체 리포트를 반환합니다.",
+            parameters = {
+                    @Parameter(name = "month", description = "조회할 연월 (yyyy-MM)", required = false, example = "2025-05")
+            }
+    )
     @GetMapping("/consumption-report")
     public List<ConsumptionHabitReportResponse> getMyReports(
-            Principal principal,
-            @Parameter(description = "조회할 연월 (yyyy-MM)", example = "2025-05")
-            @RequestParam(value = "조회할 연월 (yyyy-MM)", required = false)
-            @DateTimeFormat(pattern = "yyyy-MM") YearMonth month
+            @RequestParam(value = "month", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
+            Principal principal
     ) {
         Long memberId = Long.parseLong(principal.getName());
         Member member = memberService.findById(memberId);
@@ -52,5 +57,4 @@ public class ConsumptionHabitReportController {
                     .toList();
         }
     }
-
 }

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
@@ -6,7 +6,6 @@ import com.flexrate.flexrate_back.report.application.ReportStatisticsService;
 import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryStatsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
@@ -6,6 +6,7 @@ import com.flexrate.flexrate_back.report.application.ReportStatisticsService;
 import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryStatsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -29,13 +30,23 @@ public class ReportStatisticsController {
      * @since 2025.05.08
      * @author 서채연
      */
-    @Operation(summary = "카테고리별 소비 통계 조회", description = "해당 월의 소비 통계를 카테고리 기준으로 집계하여 반환합니다.")
+    @Operation(
+            summary = "카테고리별 소비 통계 조회",
+            description = "해당 월의 소비 통계를 카테고리 기준으로 집계하여 반환합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "month",
+                            description = "조회할 연월 (yyyy-MM)",
+                            required = true,
+                            example = "2025-05"
+                    )
+            }
+    )
     @GetMapping("/consumption-statistic")
     public ConsumptionCategoryStatsResponse getMyStats(
-            Principal principal,
-            @Parameter(description = "조회할 연월 (yyyy-MM)", example = "2025-05")
-            @RequestParam("조회할 연월 (yyyy-MM)")
-            @DateTimeFormat(pattern = "yyyy-MM") YearMonth month
+            @RequestParam(value = "month")
+            @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
+            Principal principal
     ) {
         Long memberId = Long.parseLong(principal.getName());
         Member member = memberService.findById(memberId);

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
@@ -21,6 +21,14 @@ public class ReportStatisticsController {
     private final ReportStatisticsService statisticsService;
     private final MemberService memberService;
 
+    /**
+     * 사용자 본인의 카테고리별 소비 통계 조회 API
+     * @param principal 현재 로그인한 사용자 정보
+     * @param month 통계를 조회할 연월 (yyyy-MM 형식)
+     * @return 카테고리별 소비 통계 응답 객체
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Operation(summary = "카테고리별 소비 통계 조회", description = "해당 월의 소비 통계를 카테고리 기준으로 집계하여 반환합니다.")
     @GetMapping("/consumption-statistic")
     public ConsumptionCategoryStatsResponse getMyStats(

--- a/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/ReportStatisticsController.java
@@ -1,0 +1,37 @@
+package com.flexrate.flexrate_back.report.api;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.report.application.ReportStatisticsService;
+import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryStatsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.time.YearMonth;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/statistics")
+public class ReportStatisticsController {
+
+    private final ReportStatisticsService statisticsService;
+    private final MemberService memberService;
+
+    @Operation(summary = "카테고리별 소비 통계 조회", description = "해당 월의 소비 통계를 카테고리 기준으로 집계하여 반환합니다.")
+    @GetMapping("/consumption-statistic")
+    public ConsumptionCategoryStatsResponse getMyStats(
+            Principal principal,
+            @Parameter(description = "조회할 연월 (yyyy-MM)", example = "2025-05")
+            @RequestParam("조회할 연월 (yyyy-MM)")
+            @DateTimeFormat(pattern = "yyyy-MM") YearMonth month
+    ) {
+        Long memberId = Long.parseLong(principal.getName());
+        Member member = memberService.findById(memberId);
+
+        return statisticsService.getCategoryStats(member, month);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/api/SchedulerTestController.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/api/SchedulerTestController.java
@@ -1,0 +1,22 @@
+package com.flexrate.flexrate_back.report.api;
+
+import com.flexrate.flexrate_back.report.scheduler.ConsumptionHabitReportScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test")
+@RequiredArgsConstructor
+public class SchedulerTestController {
+
+    private final ConsumptionHabitReportScheduler scheduler;
+
+    @PostMapping("/run-report-scheduler")
+    public ResponseEntity<Void> runScheduler() {
+        scheduler.generateMonthlyReports();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportService.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportService.java
@@ -1,0 +1,17 @@
+package com.flexrate.flexrate_back.report.application;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.domain.ConsumptionHabitReport;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+public interface ConsumptionHabitReportService {
+
+    void createReport(Member member, YearMonth reportMonth, String summary);
+
+    Optional<ConsumptionHabitReport> getReport(Member member, YearMonth reportMonth);
+
+    List<ConsumptionHabitReport> getAllReportsByMember(Member member);
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportServiceImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportServiceImpl.java
@@ -1,0 +1,49 @@
+package com.flexrate.flexrate_back.report.application;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.client.ConsumptionReportApiClient;
+import com.flexrate.flexrate_back.report.domain.ConsumptionHabitReport;
+import com.flexrate.flexrate_back.report.domain.repository.ConsumptionHabitReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ConsumptionHabitReportServiceImpl implements ConsumptionHabitReportService {
+
+    private final ConsumptionHabitReportRepository reportRepository;
+    private final ConsumptionReportApiClient apiClient;
+
+    @Override
+    public void createReport(Member member, YearMonth reportMonth, String summary) {
+        if (reportRepository.findByMemberAndReportMonth(member, reportMonth).isPresent()) {
+            throw new IllegalStateException("이미 존재");
+        }
+
+        if (summary == null || summary.isBlank()) {
+             summary = apiClient.getConsumptionSummary(member.getMemberId(), reportMonth);
+        }
+
+        reportRepository.save(
+                ConsumptionHabitReport.builder()
+                        .member(member)
+                        .reportMonth(reportMonth)
+                        .summary(summary)
+                        .build()
+        );
+    }
+
+    @Override
+    public Optional<ConsumptionHabitReport> getReport(Member member, YearMonth reportMonth) {
+        return reportRepository.findByMemberAndReportMonth(member, reportMonth);
+    }
+
+    @Override
+    public List<ConsumptionHabitReport> getAllReportsByMember(Member member) {
+        return reportRepository.findAllByMember(member);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportServiceImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportServiceImpl.java
@@ -18,6 +18,15 @@ public class ConsumptionHabitReportServiceImpl implements ConsumptionHabitReport
     private final ConsumptionHabitReportRepository reportRepository;
     private final ConsumptionReportApiClient apiClient;
 
+    /**
+     * 특정 회원의 특정 월 소비습관 리포트를 생성
+     * @param member 리포트를 생성할 대상 회원
+     * @param reportMonth 생성할 리포트의 대상 월 (yyyy-MM)
+     * @param summary 소비 요약 내용 (null이면 외부 API 요청)
+     * @throws IllegalStateException 중복된 리포트가 이미 존재하는 경우
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Override
     public void createReport(Member member, YearMonth reportMonth, String summary) {
         if (reportRepository.findByMemberAndReportMonth(member, reportMonth).isPresent()) {
@@ -37,11 +46,26 @@ public class ConsumptionHabitReportServiceImpl implements ConsumptionHabitReport
         );
     }
 
+    /**
+     * 특정 회원의 특정 월에 해당하는 소비습관 리포트 조회
+     * @param member 조회 대상 회원
+     * @param reportMonth 조회할 리포트의 월 (yyyy-MM)
+     * @return 해당 월 리포트가 존재할 경우 Optional에 래핑되어 반환, 없으면 빈 Optional
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Override
     public Optional<ConsumptionHabitReport> getReport(Member member, YearMonth reportMonth) {
         return reportRepository.findByMemberAndReportMonth(member, reportMonth);
     }
 
+    /**
+     * 특정 회원이 작성한 모든 소비습관 리포트 목록 조회
+     * @param member 조회 대상 회원
+     * @return 소비습관 리포트 목록
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Override
     public List<ConsumptionHabitReport> getAllReportsByMember(Member member) {
         return reportRepository.findAllByMember(member);

--- a/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportServiceImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/application/ConsumptionHabitReportServiceImpl.java
@@ -1,5 +1,7 @@
 package com.flexrate.flexrate_back.report.application;
 
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.report.client.ConsumptionReportApiClient;
 import com.flexrate.flexrate_back.report.domain.ConsumptionHabitReport;
@@ -23,14 +25,14 @@ public class ConsumptionHabitReportServiceImpl implements ConsumptionHabitReport
      * @param member 리포트를 생성할 대상 회원
      * @param reportMonth 생성할 리포트의 대상 월 (yyyy-MM)
      * @param summary 소비 요약 내용 (null이면 외부 API 요청)
-     * @throws IllegalStateException 중복된 리포트가 이미 존재하는 경우
+     * @throws FlexrateException REPORT_ALREADY_EXISTS 중복된 리포트가 이미 존재하는 경우
      * @since 2025.05.08
      * @author 서채연
      */
     @Override
     public void createReport(Member member, YearMonth reportMonth, String summary) {
         if (reportRepository.findByMemberAndReportMonth(member, reportMonth).isPresent()) {
-            throw new IllegalStateException("이미 존재");
+            throw new FlexrateException(ErrorCode.REPORT_ALREADY_EXISTS);
         }
 
         if (summary == null || summary.isBlank()) {

--- a/src/main/java/com/flexrate/flexrate_back/report/application/ReportStatisticsService.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/application/ReportStatisticsService.java
@@ -1,0 +1,28 @@
+package com.flexrate.flexrate_back.report.application;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryRatioResponse;
+import com.flexrate.flexrate_back.report.dto.ConsumptionCategoryStatsResponse;
+import com.flexrate.flexrate_back.financialdata.domain.repository.UserFinancialDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportStatisticsService {
+
+    private final UserFinancialDataRepository financialDataRepository;
+
+    public ConsumptionCategoryStatsResponse getCategoryStats(Member member, YearMonth month) {
+        List<ConsumptionCategoryRatioResponse> stats = financialDataRepository.findCategoryStatsWithRatio(member, month);
+
+        return new ConsumptionCategoryStatsResponse(
+                member.getMemberId(),
+                month,
+                stats
+        );
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/application/ReportStatisticsService.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/application/ReportStatisticsService.java
@@ -16,6 +16,14 @@ public class ReportStatisticsService {
 
     private final UserFinancialDataRepository financialDataRepository;
 
+    /**
+     * 특정 회원의 지정 월에 대한 카테고리별 소비 통계 조회
+     * @param member 조회 대상 회원
+     * @param month 조회할 연월 (yyyy-MM)
+     * @return 해당 회원의 카테고리별 소비 통계 응답 DTO
+     * @since 2025.05.08
+     * @author 서채연
+     */
     public ConsumptionCategoryStatsResponse getCategoryStats(Member member, YearMonth month) {
         List<ConsumptionCategoryRatioResponse> stats = financialDataRepository.findCategoryStatsWithRatio(member, month);
 

--- a/src/main/java/com/flexrate/flexrate_back/report/client/ConsumptionReportApiClient.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/client/ConsumptionReportApiClient.java
@@ -1,0 +1,20 @@
+package com.flexrate.flexrate_back.report.client;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.YearMonth;
+
+@Component
+public class ConsumptionReportApiClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String getConsumptionSummary(Long memberId, YearMonth reportMonth) {
+        String url = String.format(
+                "https://openapi.example.com/analysis/summary?memberId=%d&month=%s",
+                memberId, reportMonth.toString()
+        );
+        return restTemplate.getForObject(url, String.class);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/client/ConsumptionReportApiClient.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/client/ConsumptionReportApiClient.java
@@ -10,6 +10,14 @@ public class ConsumptionReportApiClient {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
+    /**
+     * 외부 OpenAPI를 통해 특정 회원의 소비 데이터를 요약한 리포트 조회
+     * @param memberId 외부 API 요청에 사용될 회원 ID
+     * @param reportMonth 조회 대상 월 (yyyy-MM)
+     * @return 소비 리포트 요약 문자열
+     * @since 2025.05.08
+     * @author 서채연
+     */
     public String getConsumptionSummary(Long memberId, YearMonth reportMonth) {
         String url = String.format(
                 "https://openapi.example.com/analysis/summary?memberId=%d&month=%s",

--- a/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitReport.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitReport.java
@@ -1,0 +1,45 @@
+package com.flexrate.flexrate_back.report.domain;
+
+import com.flexrate.flexrate_back.common.converter.YearMonthAttributeConverter;
+import com.flexrate.flexrate_back.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+@Entity
+@Table(
+        name = "ConsumptionHabitReport",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "report_month"})
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConsumptionHabitReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Convert(converter = YearMonthAttributeConverter.class)
+    @Column(name = "report_month", nullable = false, length = 7)
+    private YearMonth reportMonth;
+
+    @Column(length = 500)
+    private String summary;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDate createdAt;
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/domain/repository/ConsumptionHabitReportRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/domain/repository/ConsumptionHabitReportRepository.java
@@ -1,0 +1,14 @@
+package com.flexrate.flexrate_back.report.domain.repository;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.report.domain.ConsumptionHabitReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+public interface ConsumptionHabitReportRepository extends JpaRepository<ConsumptionHabitReport, Long> {
+    Optional<ConsumptionHabitReport> findByMemberAndReportMonth(Member member, YearMonth reportMonth);
+    List<ConsumptionHabitReport> findAllByMember(Member member);
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/dto/ConsumptionCategoryRatioResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/dto/ConsumptionCategoryRatioResponse.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.report.dto;
+
+public record ConsumptionCategoryRatioResponse(
+        String category,
+        int amount,
+        double percentage
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/report/dto/ConsumptionCategoryStatsResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/dto/ConsumptionCategoryStatsResponse.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.report.dto;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public record ConsumptionCategoryStatsResponse(
+        Long memberId,
+        YearMonth month,
+        List<ConsumptionCategoryRatioResponse> stats
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/report/dto/ConsumptionHabitReportResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/dto/ConsumptionHabitReportResponse.java
@@ -1,0 +1,24 @@
+package com.flexrate.flexrate_back.report.dto;
+
+import com.flexrate.flexrate_back.report.domain.ConsumptionHabitReport;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+public record ConsumptionHabitReportResponse(
+        Long reportId,
+        Long memberId,
+        YearMonth reportMonth,
+        String summary,
+        LocalDate createdAt
+) {
+    public static ConsumptionHabitReportResponse from(ConsumptionHabitReport report) {
+        return new ConsumptionHabitReportResponse(
+                report.getReportId(),
+                report.getMember().getMemberId(),
+                report.getReportMonth(),
+                report.getSummary(),
+                report.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/scheduler/ConsumptionHabitReportScheduler.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/scheduler/ConsumptionHabitReportScheduler.java
@@ -1,0 +1,39 @@
+package com.flexrate.flexrate_back.report.scheduler;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import com.flexrate.flexrate_back.report.application.ConsumptionHabitReportService;
+import com.flexrate.flexrate_back.report.client.ConsumptionReportApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConsumptionHabitReportScheduler {
+
+    private final MemberRepository memberRepository;
+    private final ConsumptionHabitReportService reportService;
+    private final ConsumptionReportApiClient apiClient;
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void generateMonthlyReports() {
+        YearMonth targetMonth = YearMonth.now().minusMonths(1);
+        List<Member> members = memberRepository.findAll();
+
+        for (Member member : members) {
+            try {
+                String summary = apiClient.getConsumptionSummary(member.getMemberId(), targetMonth);
+                reportService.createReport(member, targetMonth, summary);
+                log.info("[ReportScheduler] {}월 리포트 생성 완료 - {}", targetMonth, member.getEmail());
+            } catch (Exception e) {
+                log.warn("[ReportScheduler] {}월 리포트 생성 실패 - {}: {}", targetMonth, member.getEmail(), e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/scheduler/ConsumptionHabitReportScheduler.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/scheduler/ConsumptionHabitReportScheduler.java
@@ -21,6 +21,11 @@ public class ConsumptionHabitReportScheduler {
     private final ConsumptionHabitReportService reportService;
     private final ConsumptionReportApiClient apiClient;
 
+    /**
+     * 매월 1일 자정에 실행되는 소비습관 리포트 자동 생성 스케줄러
+     * @since 2025.05.08
+     * @author 서채연
+     */
     @Scheduled(cron = "0 0 0 1 * ?")
     public void generateMonthlyReports() {
         YearMonth targetMonth = YearMonth.now().minusMonths(1);


### PR DESCRIPTION
## 🔥 Related Issues

- close #52 

## 💜 작업 내용

- [x] YearMonthAttributeConverter 작업

### 카테고리별 소비 통계 관련
- [x] UserFinancialCategory ENUM 추가
- [x] ConsumptionCategoryRatioResponse, ConsumptionCategoryStatsResponse
- [x] UserFinancialDataRepository
- [x] ReportStatisticsService
- [x] ReportStatisticsController

### 소비 습관 개선 리포트 관련
- [x] ConsumptionHabitReport(소비습관리포트) 엔터티 생성(Member와 @ManyToOne 관계)
- [x] ConsumptionHabitReportRepository
- [x] ConsumptionHabitReportService + 구현체
- [x] ConsumptionHabitReportController
- [x] ConsumptionHabitReportResponse
- [x] ConsumptionHabitReportScheduler

## ✅ PR Point

<img width="250" alt="image" src="https://github.com/user-attachments/assets/b4ca0ade-9eac-4601-a27b-bb662f83aaf6" />


### 카테고리별 소비 통계와 소비 습관 개선 리포트 두 섹션으로 나눠서 API 작업을 진행했습니다.

### YearMonthAttributeConverter(날짜 데이터 변환 코드)
연월만 필요하기 때문에 YearMonth 타입으로 reportMonth를 선언하였습니다.
하지만 JPA에서는 YearMonth를 매핑하지 못하기 때문에 문자열로 변환시켜 저장할 수 있도록 하기 위해 다음과 같은 변환 코드를 만들었습니다.

```java
package com.flexrate.flexrate_back.common.converter;

import jakarta.persistence.AttributeConverter;
import jakarta.persistence.Converter;

import java.time.YearMonth;
import java.time.format.DateTimeFormatter;

@Converter(autoApply = false)
public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {

    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");

    @Override
    public String convertToDatabaseColumn(YearMonth attribute) {
        return attribute != null ? attribute.format(FORMATTER) : null;
    }

    @Override
    public YearMonth convertToEntityAttribute(String dbData) {
        return dbData != null ? YearMonth.parse(dbData, FORMATTER) : null;
    }
}
```

### UserFinancialCategory ENUM 추가 및 UserFinancialData 엔터티 수정

소비 데이터의 카테고리 값을 쥐어주기 위해 카테고리 ENUM과 소비 데이터 엔터티에 카테고리를 추가하였습니다.

```java
public enum UserFinancialCategory {
    FOOD,
    LIVING,
    LEISURE,
    TRANSPORT,
    COMMUNICATION,
    EDUCATION,
    HEALTH,
    ETC,
}
```

```java
// UserFinancialData 엔터티에 추가
@Enumerated(EnumType.STRING)
@Column
private UserFinancialCategory category;
```

### ConsumptionHabitReport(소비 습관 개선 리포트 엔터티) 생성

소비 데이터를 기반으로 월별 소비 습관 개선 리포트를 나타내줄 엔터티를 생성하였습니다.

### UserFinancialDataQueryRepositoryImpl
사용자 지출 통계를 계산하는 로직이 들어간 구현체입니다.
특정 회원, 특정 월 기준으로 EXPENSE 타입 데이터를 집계하여 카테고리별 합계 및 전체 대비 비율을 계산하여 ConsumptionCategoryRatioResponse로 반환해줍니다.

👉🏻 b0788dd4f4d1a1fce852c668d1d290fc36c628d7

### ReportStatisticsService
회원과 조회할 연월을 입력 받아 카테고리별 지출 합계와 비율을 조회합니다. 

👉🏻 08598d9ad6c0071bbb53fa1a8c0a2fe813328e06

### ConsumptionHabitReportRepository
한 사용자의 특정 월 리포트를 하나씩 조회할 수 있는 `findByMemberAndReportMonth`와 사용자의 전체 리포트 조회를 할 수 있는`findAllByMember` 두 가지 메서드가 있습니다.

👉🏻 ed802a95320fc50ad5a39bac9d4f0d8e13a7b168

### 소비습관 리포트 생성 및 조회 로직
동일한 월 리포트가 존재하는 경우 중복 생성을 방지하고 외부 API에 리포트를 받아와 db에 저장하는 로직인 `createReport`와 한 명의 사용자에 대해 특정 월의 리포트를 조회하도록 하는 `getReport`와 한 명의 사용자가 가진 전체 리포트 목록을 조회하는 `getAllReportsByMember`가 `ConsumptionHabitReportServiceImpl`에 구현되어 있습니다. 사용자의 소비 리포트는 `ConsumptionReportApiClient`를 통해 외부 API를 호출하여 가져옵니다.

👉🏻 1b2744c24da818385471abe855b6c37b5845c497

### ConsumptionHabitReportScheduler
매월 1일 자정에 지난달 기준 소비 리포트를 생성하는 정기 스케줄링 로직을 구현했습니다.
현재 월 기준 이전 달(`YearMonth.now().minusMonths(1)`)을 타겟으로 하여 해당 달의 소비 데이터를 받아 리포트를 생성하도록 합니다.(이 로직은 외부 서버가 담당)

현재 로직상 소비 데이터가 자동으로 나오고 외부 서버에 연결할 수 없는 상태이므로 Swagger 테스트용 수동 호출(generateNextMonthlyReportsForTest)을 통해 더미 소비 데이터를 자동을 만들고 더미 summary를 랜덤으로 생성해서 띄워주는 방식으로 테스트를 진행했습니다.
테스트는 밑에 토글로 있는 두 코드를 이용해서 스웨거에서 진행하시면 됩니다.

👉🏻 9c6fb2149605d847a3efa697fa56c19147857917

<details>
<summary>⚙️ SchedulerTestController</summary>

```java
package com.flexrate.flexrate_back.report.api;

import com.flexrate.flexrate_back.report.scheduler.ConsumptionHabitReportScheduler;
import lombok.RequiredArgsConstructor;
import org.springframework.http.ResponseEntity;
import org.springframework.web.bind.annotation.PostMapping;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RestController;

@RestController
@RequestMapping("/api/test")
@RequiredArgsConstructor
public class SchedulerTestController {

    private final ConsumptionHabitReportScheduler scheduler;

    @PostMapping("/run-report-scheduler")
    public ResponseEntity<Void> runScheduler() {
        scheduler.generateNextMonthlyReportsForTest();
        return ResponseEntity.ok().build();
    }
}

```
</details>

<details>
<summary>📆 ConsumptionHabitReportScheduler</summary>

```java
package com.flexrate.flexrate_back.report.scheduler;

import com.flexrate.flexrate_back.financialdata.domain.UserFinancialData;
import com.flexrate.flexrate_back.financialdata.domain.repository.UserFinancialDataRepository;
import com.flexrate.flexrate_back.financialdata.enums.UserFinancialCategory;
import com.flexrate.flexrate_back.financialdata.enums.UserFinancialDataType;
import com.flexrate.flexrate_back.member.domain.Member;
import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
import com.flexrate.flexrate_back.report.application.ConsumptionHabitReportService;
import com.flexrate.flexrate_back.report.client.ConsumptionReportApiClient;
import com.flexrate.flexrate_back.report.domain.ConsumptionHabitReport;
import lombok.RequiredArgsConstructor;
import lombok.extern.slf4j.Slf4j;
import org.springframework.scheduling.annotation.Scheduled;
import org.springframework.stereotype.Component;

import java.time.YearMonth;
import java.util.Comparator;
import java.util.List;
import java.util.Random;

@Slf4j
@Component
@RequiredArgsConstructor
public class ConsumptionHabitReportScheduler {

    private final MemberRepository memberRepository;
    private final ConsumptionHabitReportService reportService;
    private final ConsumptionReportApiClient apiClient;
    private final UserFinancialDataRepository userFinancialDataRepository;

    @Scheduled(cron = "0 0 0 1 * ?")
    public void generateMonthlyReports() {
        YearMonth targetMonth = YearMonth.now().minusMonths(1);
        List<Member> members = memberRepository.findAll();

        for (Member member : members) {
            try {
                String summary = apiClient.getConsumptionSummary(member.getMemberId(), targetMonth);
                reportService.createReport(member, targetMonth, summary);
                log.info("[ReportScheduler] {}월 리포트 생성 완료 - {}", targetMonth, member.getEmail());
            } catch (Exception e) {
                log.warn("[ReportScheduler] {}월 리포트 생성 실패 - {}: {}", targetMonth, member.getEmail(), e.getMessage());
            }
        }
    }

    /**
     * 테스트용: Swagger에서 수동 호출 시 사용
     */
    public void generateNextMonthlyReportsForTest() {
        List<String> dummySummaries = List.of(
                "[TEST] 식비 비중이 높습니다. 외식 횟수를 줄여보세요.",
                "[TEST] 여가비가 증가했습니다. 문화생활 예산을 조절해보세요.",
                "[TEST] 보험 지출이 큽니다. 필요 항목을 점검해보세요.",
                "[TEST] 교통비가 많습니다. 대중교통 이용을 고려해보세요.",
                "[TEST] 통신비 절약이 가능합니다. 요금제를 확인해보세요."
        );

        List<Member> members = memberRepository.findAll();

        Random random = new Random();

        for (Member member : members) {
            try {
                // 현재 마지막 리포트 달 조회
                List<ConsumptionHabitReport> reports = reportService.getAllReportsByMember(member);
                YearMonth nextMonth = reports.stream()
                        .map(ConsumptionHabitReport::getReportMonth)
                        .max(Comparator.naturalOrder())
                        .map(m -> m.plusMonths(1))
                        .orElse(YearMonth.of(2025, 4));

                // 소비 더미 생성
                userFinancialDataRepository.save(
                        UserFinancialData.builder()
                                .member(member)
                                .value(random.nextInt(100000) + 1000)
                                .dataType(UserFinancialDataType.EXPENSE)
                                .category(UserFinancialCategory.values()[random.nextInt(UserFinancialCategory.values().length)])
                                .collectedAt(nextMonth.atEndOfMonth().atTime(12, 0))
                                .build()
                );

                String summary = dummySummaries.get(random.nextInt(dummySummaries.size()));

                reportService.createReport(member, nextMonth, summary);

                log.info("[ReportScheduler-Test] {}월 리포트 생성 완료 - {}", nextMonth, member.getEmail());

            } catch (Exception e) {
                log.warn("[ReportScheduler-Test] 리포트 생성 실패: {}", e.getMessage());
            }
        }
    }
}

```
</details>


## 😡 Trouble Shooting

### eq(null) 예외 발생
QueryDSL에서 eq(null) 사용 시 IllegalArgumentException: eq(null) is not allowed. Use isNull() instead 발생하는 문제
null이 아닌 것 같은데 자꾸 null로 나와서 뭐지 왜 자꾸 멤버가 null이라는 거지 멘붕 상황 발생
-> 알고 보니 토큰 인증 방식을 @AuthenticationPrincipal Member member 진행해서 따로 getPrincipal 처리를 안해줘서 멤버 값을 못 받아온 것... Principal 사용하기로 이야기했었는데 이상한 거 쓰고 있었습니다.

추가로 동적으로 조건을 누적해서 처리하기 위해 BooleanBuilder라는 걸 사용했습니다.

## ☀ 스크린샷 / GIF / 화면 녹화

### 카테고리별 소비 통계 조회
<img width="404" alt="image" src="https://github.com/user-attachments/assets/c6844bab-cb6c-4242-90ce-9556d54c738b" />

### 소비 습관 개선 리포트 조회
<img width="430" alt="image" src="https://github.com/user-attachments/assets/f6b2bfcb-dbf9-46a4-a99b-6114734ce217" />
