### PR TITLE
feature: 대출 현황 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -129,12 +129,12 @@ public class LoanAdminController {
     @GetMapping
     public ResponseEntity<LoanAdminSearchResponse> searchLoans(
             @Valid LoanAdminSearchRequest request
-            //, Principal principal
+            , Principal principal
     ) {
-//        // A007 관리자 인증 체크
-//        if (!adminAuthChecker.isAdmin(principal)) {
-//            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
-//        }
+        // A007 관리자 인증 체크
+        if (!adminAuthChecker.isAdmin(principal)) {
+            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
+        }
 
         return ResponseEntity.ok(loanAdminService.searchLoans(request));
     }

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -3,9 +3,8 @@ package com.flexrate.flexrate_back.loan.api;
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.loan.application.LoanAdminService;
-import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateRequest;
-import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateResponse;
-import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
+import com.flexrate.flexrate_back.loan.dto.*;
+import com.flexrate.flexrate_back.loan.dto.LoanAdminSearchRequest;
 import com.flexrate.flexrate_back.member.application.AdminAuthChecker;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -95,5 +94,48 @@ public class LoanAdminController {
         }
 
         return ResponseEntity.ok(loanAdminService.patchLoanApplicationStatus(loanApplicationId, request));
+    }
+
+    /**
+     * 대출 현황 리스트 조회
+     * @param request 조회할 때 원하는 필터값
+     * @return 조회된 대출 목록
+     * @since 2025.05.02
+     * @author 허연규
+     */
+    @Operation(summary = "관리자 권한으로 대출 현황 목록 조회", description = "관리자가 대출 현황 목록을 검색 조건에 따라 조회합니다.",
+            parameters = {
+                    @Parameter(name = "page", description = "페이지 번호", required = false),
+                    @Parameter(name = "size", description = "페이지 크기", required = false),
+                    @Parameter(name = "status", description = "대출 상태 리스트", required = false),
+                    @Parameter(name = "applicant", description = "신청자 이름", required = false),
+                    @Parameter(name = "applicantId", description = "신청자 ID", required = false),
+                    @Parameter(name = "appliedFrom", description = "신청일 시작일 (yyyy-MM-dd)", required = false),
+                    @Parameter(name = "appliedTo", description = "신청일 종료일 (yyyy-MM-dd)", required = false),
+                    @Parameter(name = "limitFrom", description = "대출 한도 최소값", required = false),
+                    @Parameter(name = "limitTo", description = "대출 한도 최대값", required = false),
+                    @Parameter(name = "rateFrom", description = "이자율 최소값", required = false),
+                    @Parameter(name = "rateTo", description = "이자율 최대값", required = false),
+                    @Parameter(name = "prevLoanCountFrom", description = "이전 대출 횟수 최소값", required = false),
+                    @Parameter(name = "prevLoanCountTo", description = "이전 대출 횟수 최대값", required = false),
+                    @Parameter(name = "type", description = "대출 유형 (PERSONAL, BUSINESS 등)", required = false)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "대출 거래 내역 목록 조회 성공"),
+                    @ApiResponse(responseCode = "404", description = "대출 정보를 찾을 수 없습니다", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"L002\", \"message\": \"대출 정보를 찾을 수 없습니다.\"}"))),
+                    @ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"A007\", \"message\": \"관리자 권한이 필요합니다.\"}"))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"S500\", \"message\": \"서버 내부 오류가 발생했습니다.\"}")))
+            })
+    @GetMapping
+    public ResponseEntity<LoanAdminSearchResponse> searchLoans(
+            @Valid LoanAdminSearchRequest request
+            //, Principal principal
+    ) {
+//        // A007 관리자 인증 체크
+//        if (!adminAuthChecker.isAdmin(principal)) {
+//            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
+//        }
+
+        return ResponseEntity.ok(loanAdminService.searchLoans(request));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -118,7 +118,7 @@ public class LoanAdminController {
                     @Parameter(name = "rateTo", description = "이자율 최대값", required = false),
                     @Parameter(name = "prevLoanCountFrom", description = "이전 대출 횟수 최소값", required = false),
                     @Parameter(name = "prevLoanCountTo", description = "이전 대출 횟수 최대값", required = false),
-                    @Parameter(name = "type", description = "대출 유형 (PERSONAL, BUSINESS 등)", required = false)
+                    @Parameter(name = "type", description = "대출 유형 (NEW, EXTENSION, REJOIN)", required = false)
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "대출 거래 내역 목록 조회 성공"),

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -150,7 +150,7 @@ public class LoanAdminService {
         return LoanAdminSearchResponse.builder()
                 .paginationInfo(new PaginationInfo(
                         loans.getNumber(),
-                        loans.getSize(),
+                        loans.getContent().size(),
                         loans.getTotalPages(),
                         loans.getTotalElements()
                 ))

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -4,19 +4,22 @@ import com.flexrate.flexrate_back.common.dto.PaginationInfo;
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.loan.application.repository.InterestRepository;
+import com.flexrate.flexrate_back.loan.application.repository.LoanAdminQueryRepository;
 import com.flexrate.flexrate_back.loan.application.repository.LoanApplicationRepository;
 import com.flexrate.flexrate_back.loan.application.repository.LoanTransactionQueryRepository;
 import com.flexrate.flexrate_back.loan.domain.Interest;
 import com.flexrate.flexrate_back.loan.domain.LoanApplication;
-import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateRequest;
-import com.flexrate.flexrate_back.loan.dto.LoanApplicationStatusUpdateResponse;
-import com.flexrate.flexrate_back.loan.dto.TransactionHistoryResponse;
+import com.flexrate.flexrate_back.loan.dto.*;
 import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import com.flexrate.flexrate_back.loan.mapper.LoanApplicationMapper;
 import com.flexrate.flexrate_back.loan.mapper.LoanTransactionMapper;
 import com.flexrate.flexrate_back.member.application.AdminAuthChecker;
 import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -33,6 +36,8 @@ public class LoanAdminService {
     private final LoanTransactionMapper loanTransactionMapper;
     private final MemberRepository memberRepository;
     private final InterestRepository interestRepository;
+    private final LoanAdminQueryRepository loanAdminQueryRepository;
+    private final LoanApplicationMapper loanApplicationMapper;
     /**
      * 대출 거래 내역 목록 조회
      * @param memberId 사용자 ID
@@ -118,4 +123,40 @@ public class LoanAdminService {
                 .build();
     }
 
+    /**
+     * 대출 현황 목록 조회
+     * @param request 조회할 때 원하는 필터값
+     * @return 조회된 대출 목록
+     * @since 2025.05.02
+     * @author 허연규
+     */
+
+    public LoanAdminSearchResponse searchLoans(@Valid LoanAdminSearchRequest request) {
+
+        Sort sort = Sort.by("appliedAt").descending();
+
+        Pageable pageable = PageRequest.of(
+                request.page() != null ? request.page() : 0,
+                request.size() != null ? request.size() : 20,
+                sort
+        );
+
+        Page<LoanApplication> loans = loanAdminQueryRepository.searchLoans(request, pageable);
+
+        if (loans.isEmpty()) {
+            throw new FlexrateException(ErrorCode.LOAN_NOT_FOUND);
+        }
+
+        return LoanAdminSearchResponse.builder()
+                .paginationInfo(new PaginationInfo(
+                        loans.getNumber(),
+                        loans.getSize(),
+                        loans.getTotalPages(),
+                        loans.getTotalElements()
+                ))
+                .loans(loans.getContent().stream()
+                        .map(loanApplicationMapper::toSummaryDto)
+                        .toList())
+                .build();
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanAdminQueryRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanAdminQueryRepository.java
@@ -1,0 +1,12 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanApplication;
+import com.flexrate.flexrate_back.loan.dto.LoanAdminSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoanAdminQueryRepository {
+    Page<LoanApplication> searchLoans(LoanAdminSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanAdminQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanAdminQueryRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanApplication;
+import com.flexrate.flexrate_back.loan.domain.QLoanApplication;
+import com.flexrate.flexrate_back.loan.dto.LoanAdminSearchRequest;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class LoanAdminQueryRepositoryImpl implements LoanAdminQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    QLoanApplication loan = QLoanApplication.loanApplication;
+
+    @Override
+    public Page<LoanApplication> searchLoans(LoanAdminSearchRequest request, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (request.status() != null && !request.status().isEmpty()) {
+            builder.and(loan.status.in(request.status()));
+        }
+        if (request.applicantId() != null) {
+            builder.and(loan.member.memberId.eq(request.applicantId()));
+        }
+        if (request.applicant() != null && !request.applicant().isBlank()) {
+            builder.and(loan.member.name.containsIgnoreCase(request.applicant()));
+        }
+        if (request.appliedFrom() != null) {
+            builder.and(loan.appliedAt.goe(request.appliedFrom().atStartOfDay()));
+        }
+        if (request.appliedTo() != null) {
+            builder.and(loan.appliedAt.loe(request.appliedTo().atTime(23, 59, 59)));
+        }
+        if (request.limitFrom() != null) {
+            builder.and(loan.remainAmount.goe(request.limitFrom()));
+        }
+        if (request.limitTo() != null) {
+            builder.and(loan.remainAmount.loe(request.limitTo()));
+        }
+        if (request.rateFrom() != null && request.rateFrom() > 0) {
+            builder.and(loan.rate.goe(request.rateFrom()));
+        }
+        if (request.rateTo() != null && request.rateTo() > 0) {
+            builder.and(loan.rate.loe(request.rateTo()));
+        }
+        if (request.prevLoanCountFrom() != null) {
+            builder.and(loan.loanTransactions.size().goe(request.prevLoanCountFrom()));
+        }
+        if (request.prevLoanCountTo() != null) {
+            builder.and(loan.loanTransactions.size().loe(request.prevLoanCountTo()));
+        }
+        if (request.type() != null) {
+            builder.and(loan.loanType.eq(request.type()));
+        }
+
+        List<LoanApplication> content = queryFactory
+                .selectFrom(loan)
+                .where(builder)
+                .orderBy(getOrderSpecifiers(pageable, loan))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(loan.count())
+                .from(loan)
+                .where(builder)
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> total != null ? total : 0);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable, QLoanApplication loan) {
+        if (pageable.getSort().isEmpty()) {
+            return new OrderSpecifier[]{new OrderSpecifier<LocalDateTime>(Order.DESC, loan.appliedAt)};
+        }
+        return pageable.getSort().stream()
+                .map(order -> {
+                    PathBuilder<LoanApplication> pathBuilder = new PathBuilder<>(LoanApplication.class, loan.getMetadata().getName());
+                    return new OrderSpecifier<Comparable>(
+                            order.isAscending() ? Order.ASC : Order.DESC,
+                            pathBuilder.get(order.getProperty(), Comparable.class)
+                    );
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -5,6 +5,7 @@ import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.loan.dto.LoanApplicationRequest;
 import com.flexrate.flexrate_back.loan.dto.LoanReviewApplicationResponse;
 import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import com.flexrate.flexrate_back.loan.enums.LoanType;
 import com.flexrate.flexrate_back.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -37,6 +38,10 @@ public class LoanApplication {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private LoanApplicationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LoanType loanType;
 
     private LocalDateTime executedAt;
     private int totalAmount;

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanAdminSearchRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanAdminSearchRequest.java
@@ -1,0 +1,41 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import com.flexrate.flexrate_back.loan.enums.LoanType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record LoanAdminSearchRequest(
+        @Min(value = 0, message = "페이지는 0 이상이어야 합니다.")
+        Integer page,
+
+        @Min(value = 1, message = "사이즈는 1 이상이어야 합니다.")
+        @Max(value = 200, message = "사이즈는 200 이하만 가능합니다.")
+        Integer size,
+
+        List<LoanApplicationStatus> status,
+
+        @Size(max = 10, message = "신청자 이름은 최대 10자까지 입력할 수 있습니다.")
+        String applicant,
+
+        Long applicantId,
+
+        LocalDate appliedFrom,
+        LocalDate appliedTo,
+
+        Integer limitFrom,
+        Integer limitTo,
+
+        Float rateFrom,
+        Float rateTo,
+
+        Integer prevLoanCountFrom,
+        Integer prevLoanCountTo,
+
+        LoanType type
+) {
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanAdminSearchResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanAdminSearchResponse.java
@@ -1,0 +1,12 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import com.flexrate.flexrate_back.common.dto.PaginationInfo;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record LoanAdminSearchResponse(
+        PaginationInfo paginationInfo,
+        List<LoanAdminSearchSummaryDto> loans
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanAdminSearchSummaryDto.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanAdminSearchSummaryDto.java
@@ -1,0 +1,18 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record LoanAdminSearchSummaryDto(
+        Long id,
+        String status,
+        LocalDate appliedAt,
+        String applicant,
+        Long applicantId,
+        Integer availableLimit,
+        Float initialRate,
+        Integer prevLoanCount,
+        String type
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanType.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanType.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.loan.enums;
+
+public enum LoanType {
+    NEW,
+    EXTENSION,
+    REJOIN
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanApplicationMapper.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanApplicationMapper.java
@@ -1,0 +1,23 @@
+package com.flexrate.flexrate_back.loan.mapper;
+
+import com.flexrate.flexrate_back.loan.domain.LoanApplication;
+import com.flexrate.flexrate_back.loan.dto.LoanAdminSearchSummaryDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoanApplicationMapper {
+
+    public LoanAdminSearchSummaryDto toSummaryDto(LoanApplication loan) {
+        return LoanAdminSearchSummaryDto.builder()
+                .id(loan.getApplicationId())
+                .status(loan.getStatus().name())
+                .appliedAt(loan.getAppliedAt().toLocalDate())
+                .applicant(loan.getMember().getName())
+                .applicantId(loan.getMember().getMemberId())
+                .availableLimit(loan.getRemainAmount())
+                .initialRate(loan.getRate())
+                .prevLoanCount(loan.getLoanTransactions().size())
+                .type(loan.getLoanType() != null ? loan.getLoanType().name() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberAdminController.java
@@ -97,10 +97,8 @@ public class MemberAdminController {
                     @ApiResponse(responseCode = "400", description = "사용자가 존재하지 않음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"U001\", \"message\": \"사용자를 찾을 수 없습니다.\"}"))),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"S500\", \"message\": \"서버 내부 오류\"}"))),
             }
-            //security = { @SecurityRequirement(name = "bearerAuth") }
     )
     @GetMapping("/{memberId}")
-    // @PreAuthorize("hasRole('ADMIN')") - 우선은 adminToken으로 테스트
     public ResponseEntity<MemberDetailResponse> getMemberDetail(
             @PathVariable Long memberId,
             Principal principal


### PR DESCRIPTION
## 🔥 Related Issues

- close #49 

## 💜 작업 내용

- [x] 대출 현황 리스트 조회 API 구현
- [x] LoanApplication 수정
- [x] LoanType ENUM 추가
- [x] LoanAdminController, Service에 코드 추가
- [x] LoanAdminQueryRepository, LoanAdminQueryRepositoryImpl 추가
- [x] LoanAdminSearchRequest, Response, DTO 추가
- [x] LoanApplicationMapper 추가
- [x] MemberAdminController 관리자 인증 부분 기존에 작성했던 코드 제거

## ✅ PR Point

- loanApplication을 가져다가 작업했습니다. 코드에 변경사항이 있습니다.
```
  @Enumerated(EnumType.STRING)
  @Column(nullable = false)
    private LoanType loanType;
```
ENUM에 LoanType이 추가되었습니다.

- 명세서에 있던 LoanStatus의 경우 LoanApplicationStatus를 그대로 쓰면 될 것 같아 그대로 가져다 썼습니다. LoanType의 경우, 신규, 연장, 재가입이라고 되어있어 우선 넣긴 했는데... 그때 멘토님이 대출기간 연장을 말씀하셨던 것 같아 신규와 연장은 가져가는 게 맞는 것 같고, 재가입은… 아마 동일한 상품을 또 대출 받았을 때를 의미하는 게 아닌가 생각해서 이것도 그대로 가져가도 될 것 같다고 보는데 아닐 경우에는 LoanType ENUM 다시 수정하겠습니다.

- limitFrom과 limitTo의 경우 대출 가능 한도라고 되어있어서 처음에는 총 한도를 기준으로 하려고 했는데, 조회 시점에서 대출 가능한 한도를 기준으로 둔다면 totalAmount보다는 remainAmount가 적합하다고 생각하여 remainAmount로 바꾸었습니다.

- prevLoanCountFrom과 To의 경우에도 count를 기존 대출 횟수 최소라고 되어있는데 대출 횟수를 대출 거래(납입) 횟수라고 생각해서 transaction을 기준으로 count하게 하였습니다. 근데 생각해보니까 기존 대출 횟수면 한 member가 몇 개의 application을 가지고 있는지 따져야 하는 것 같아서... 그렇게 되면 member에서도
```
@OneToMany(mappedBy = "member")
private List<LoanApplication> loanApplications;
```
로 수정을 해야할 것 같아 우선 transaction 기준 count한 로직을 남겨두었는데 application 개수 count하는 로직으로 바꾸는 게 좋을까요?

 - 기존 대출 횟수를 따지려면 특정 대출 application을 기준으로 두었을 때 그 application을 가진 member가 그동안 받았던 대출 중에 실행일이 기준 application 이전인 것들을 찾아서 count해주는 식으로 로직을 수정해야 할 것 같습니다. 그게 아니라 조회된 대출의 transaction을 count로 둔다면 prevLoanCount가 아니라 transactionCount로 이름을 바꾸는 게 좋을 것 같긴 하네요... transaction 기준으로 count한다면 해당사항 수정하겠습니다.


## 😡 Trouble Shooting

- LoanAdminQueryRepositoryImpl 부분에서 로직에 잘못된 필드값을 끌어와서 전체적으로 수정을 좀 했는데 챗GPT한테 놓친 부분 있는지 묻다가 return new PageImpl<>(content, pageable, total); 코드를 return PageableExecutionUtils.getPage(content, pageable, () -> total != null ? total : 0); 로 바꾸라고 추천받았습니다. PageImpl는 단순한 구현 방식이고 PagebleExecutionUtils.getPage()의 경우에는 성능 최적화에 유리하고 count 쿼리가 복잡하거나 성능 이슈 있을 경우, 지금 제가 구현한 것처럼 동적 쿼리 + 페이징(JPAQueryFactory, QueryDSL 등 사용)을 할 경우에는 PagebleExecutionUtils.getPage()를 사용하는 것이 더 낫다고 하여 변경하였습니다.

## ☀ 스크린샷 / GIF / 화면 녹화

1. http://localhost:8080/api/admin/loans?page=0&size=2&applicant=홍길동 (이름으로 조회)
![image](https://github.com/user-attachments/assets/d69ebd0f-06d0-4294-97dd-eba14ca1f183)

2. http://localhost:8080/api/admin/loans?page=0&size=2&applicantId=1002 (아이디로 조회)
![image](https://github.com/user-attachments/assets/5ad9442b-e02e-4263-a16b-13f2fb93e52e)

3. http://localhost:8080/api/admin/loans?page=0&size=3&status=EXECUTED&&status=PENDING (status로 조회, 복수 가능)
![image](https://github.com/user-attachments/assets/834973c4-0991-4495-a123-28402bd65208)
![image](https://github.com/user-attachments/assets/7d704a74-7c60-48b9-bfae-848359c57a4a)

4. http://localhost:8080/api/admin/loans?page=0&size=3&appliedFrom=2024-07-11&appliedTo=2024-08-10 (대출 실행시점 기준으로)
![image](https://github.com/user-attachments/assets/cd7bca29-5e10-45f6-952b-83f678990340)

5. http://localhost:8080/api/admin/loans?page=0&size=3&limitFrom=100&limitTo=1000000 (대출 가능 한도로 조회)
![image](https://github.com/user-attachments/assets/d498d38d-4878-40b6-8e48-c86bd2ac66e1)
http://localhost:8080/api/admin/loans?page=1&size=1&limitFrom=100&limitTo=1000000
![image](https://github.com/user-attachments/assets/e7a98fb4-c1ad-45ca-945c-7ae825587781)

6. http://localhost:8080/api/admin/loans?page=0&size=1&rateFrom=12.0&rateFrom=15.0 (이자율 기준으로 조회)
![image](https://github.com/user-attachments/assets/36c6bd2c-cb13-4907-9da9-3e0c5735950e)

7. 페이지, 사이즈, 이름 제한 테스트
![image](https://github.com/user-attachments/assets/6d5efd3a-ee3b-4703-be08-cbaab3f4b38b)

8. 존재하지 않는 데이터 입력 시 
![image](https://github.com/user-attachments/assets/d23af28d-14c7-4a92-bc12-7013da03f655)

9. swagger 화면
![image](https://github.com/user-attachments/assets/eaa9c236-6f5f-4999-9c69-55363a389a9e)
![image](https://github.com/user-attachments/assets/3546b73b-8613-48a2-8721-75ca9f07cded)
![image](https://github.com/user-attachments/assets/696f0d06-8468-479f-8127-d5ebff2432a8)
![image](https://github.com/user-attachments/assets/4325395c-fb38-433a-8d2e-f36a8510f609)
대출... 타입... 설명 부분 수정해야겠네요...^^


## 📚 Reference

