### PR TITLE
fix: 관리자용 사용자 정보 상세 조회 API 로직 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -168,7 +168,7 @@ public class MemberAdminService {
                     .loanStartDate(app.getStartDate().toString())
                     .loanEndDate(app.getEndDate().toString())
                     .loanAmount(app.getTotalAmount())
-                    .repaymentDay(repaymentDay)
+                    .paymentDue(repaymentDay)
                     .monthlyPayment(monthlyPayment);
         }
         

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberDetailResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberDetailResponse.java
@@ -16,7 +16,10 @@ public record MemberDetailResponse(
         String consumeGoal,
         Float interestRate,
         Integer creditScore,
+        String loanStartDate,
+        String loanEndDate,
+        Integer loanAmount,
         Integer totalPayment,
-        String paymentDue,
+        Integer repaymentDay,
         Integer monthlyPayment
 ) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberDetailResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberDetailResponse.java
@@ -19,7 +19,6 @@ public record MemberDetailResponse(
         String loanStartDate,
         String loanEndDate,
         Integer loanAmount,
-        Integer totalPayment,
-        Integer repaymentDay,
+        Integer paymentDue,
         Integer monthlyPayment
 ) {}


### PR DESCRIPTION
## 🔥 Related Issues

- close #63 

## 💜 작업 내용

- [x] 대출 시작일, 대출 종료일을 MemberDetailResponse와 MemberAdminService에 추가
- [x] 납입일(paymentDue)를 YYYY-MM-DD가 아니라 DD만 return
- [x] totalPayment는 대출원리금이 아닌 대출 원금을 조회
- [x] 총 상환 금액 추가

## ✅ PR Point
![image](https://github.com/user-attachments/assets/b390fa71-3c69-4b3f-8830-72f6b417fd02)

- startDate, endDate를 끌어다 대출 시작일과 대출 종료일을 return 했습니다.

- 납입일의 경우 기존의 YYYY-MM-DD 형식이 아니라 일자만 getDayOfMonth()로 분리하여 return 했습니다.

- 대출 원금은 대출 받을 때 결정된 대출 총액을 가져왔습니다.

- 총 상환 금액의 경우에는 지금까지 상환한 금액을 나타내는 건지, 아니면 대출 총액(대출 받은 원금)에 현재 조회된 이자율을 적용했을 때 예상되는 총 상환 금액을 보여주는 건지 모르겠어서 후자로 해두었습니다. 조회날짜의 이자율을 기준으로 구한 월 납입금에 전체 대출 기간(예: 12개월 상품이면 12만큼)을 곱해서 보여주는 방식으로 실제 총 상환 금액과는 분명한 차이가 있으리라고 생각합니다. 총 상환 금액을 보여주고자 하는 의도가 이자율이 변경됨에 따라 총 상환금액이 얼마나 줄어드는지 보여줌으로써 소비습관 개선을 장려하기 위함이라면 괜찮을 거라고 생각합니다.

하지만 총 상환 금액이 지금까지 상환한 금액을 나타내는 거라면 LoanApplication 엔티티에 총 상환 금액 필드를 만들고 월 납입일마다 납입금액을 상환할 때 총 상환 금액 또한 업데이트하는 식으로 LoanTransaction 쪽에서 로직을 생성해야 할 것 같습니다. 상세 조회에서는 해당 값을 단순히 조회하는 방식으로 가야합니다.

![image](https://github.com/user-attachments/assets/2e544abe-8719-4041-a1b2-87d97abadd22)

원리금균등분할상환의 경우 위와 같은 계산식을 이용합니다. 상세 조회에서도 월 납입금을 이러한 방식으로 산정하고 있습니다. 저희 상품은 매일 이자율이 달라지므로 납입금액 또한 납입일마다 달라져서 이미 저장된 총 상환 금액이 없다면 계산이 매우 복잡해집니다. Interest의 데이터에서 납입일의 interestRate 값들을 가져다가 처음부터 계산을 해야하는데 상세 조회에서 처리하기에는 맞지 않는다고 생각했습니다.

### -> **총 상환 금액 제거**

## 😡 Trouble Shooting

- 더미데이터에 넣어둔 임시 값이 실제 계산 값과 맞지 않아 납입금액 및 총 상환 금액 계산값이 이상하게 산출되어 최대한 비슷하게 적용하여 재테스트했습니다.

- response와 관련하여 hasLoan 값이 true가 아니라면 이미지 상의 값들은 넘겨줄 필요가 없거나 0, 혹은 null 값을 넘겨줘야 하는 게 아닌 가 생각했습니다. 다만, response를 hasLoan 값에 따라서 다르게 넘겨주려고 찾아봤더니 record가 아닌 class로 바꾸어야 한다고 해서 해당 사항은 아직 추가하지 않았습니다.
-> responsebuilder를
```
// hasLoan이 true일 경우에만 대출 관련 필드 추가
    if (hasLoan) {
        responseBuilder
                .interestRate(interestRate)
                .creditScore(app.getCreditScore())
                .loanStartDate(app.getStartDate().toString())
                .loanEndDate(app.getEndDate().toString())
                .loanAmount(app.getTotalAmount())
                .totalPayment(totalPayment)
                .repaymentDay(repaymentDay)
                .monthlyPayment(monthlyPayment);
    }
```
적용해서 바꾸었습니다. hasLoan이 false면 null값이 들어갑니다.

- repaymentDay를 다시 paymentDue로 바꾸었습니다.

## ☀ 스크린샷 / GIF / 화면 녹화

일단 현재까지 변경된 사항이 적용된 모습은 아래와 같습니다.

![image](https://github.com/user-attachments/assets/ae0dc9a2-5bcf-4738-83cb-1fa1b0577851)


**추가 수정 후 결과**

![image](https://github.com/user-attachments/assets/954d46ac-0583-4933-b769-37989bea6dce)


