### PR TITLE
chore: flyway 마이그레이션 파일 작성

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/financialdata/enums/UserFinancialDataType.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/enums/UserFinancialDataType.java
@@ -2,6 +2,5 @@ package com.flexrate.flexrate_back.financialdata.enums;
 
 public enum UserFinancialDataType {
     INCOME,
-    EXPENSE,
-    LOAN_BALANCE
+    EXPENSE
 }

--- a/src/main/java/com/flexrate/flexrate_back/notification/enums/NotificationType.java
+++ b/src/main/java/com/flexrate/flexrate_back/notification/enums/NotificationType.java
@@ -2,5 +2,6 @@ package com.flexrate.flexrate_back.notification.enums;
 
 public enum NotificationType {
     LOAN_APPROVAL,
-    MATURITY_NOTICE
+    MATURITY_NOTICE,
+    INTEREST_RATE_CHANGE
 }

--- a/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitCategory.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitCategory.java
@@ -1,0 +1,35 @@
+package com.flexrate.flexrate_back.report.domain;
+
+import com.flexrate.flexrate_back.financialdata.enums.UserFinancialCategory;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "ConsumptionHabitCategory")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConsumptionHabitCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private ConsumptionHabitReport report;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserFinancialCategory category;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(nullable = false, precision = 5, scale = 2)
+    private BigDecimal ratio;
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitReport.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitReport.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.List;
 
 @Entity
 @Table(
@@ -42,4 +43,7 @@ public class ConsumptionHabitReport {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDate createdAt;
+
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ConsumptionHabitCategory> categories;
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ spring:
       leak-detection-threshold: 2000
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
       leak-detection-threshold: 2000
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,22 +1,46 @@
 -- MEMBER (회원)
 create table member
 (
-    birth_date               date null,
-    created_at               datetime(6) null,
-    last_login_at            datetime(6) null,
+    age                      int                                                                                                                                                                                                                                                                                                                                                                         null,
+    birth_date               date                                                                                                                                                                                                                                                                                                                                                                        null,
+    created_at               datetime(6)                                                                                                                                                                                                                                                                                                                                                                 null,
+    last_login_at            datetime(6)                                                                                                                                                                                                                                                                                                                                                                 null,
     member_id                bigint auto_increment primary key,
-    password_last_changed_at datetime(6) null,
-    updated_at               datetime(6) null,
-    name                     varchar(20) not null,
-    phone                    varchar(20) null,
-    email                    varchar(50) not null,
-    password_hash            varchar(255) not null,
+    password_last_changed_at datetime(6)                                                                                                                                                                                                                                                                                                                                                                 null,
+    updated_at               datetime(6)                                                                                                                                                                                                                                                                                                                                                                 null,
+    name                     varchar(20)                                                                                                                                                                                                                                                                                                                                                                 not null,
+    phone                    varchar(20)                                                                                                                                                                                                                                                                                                                                                                 null,
+    email                    varchar(50)                                                                                                                                                                                                                                                                                                                                                                 not null,
+    password_hash            varchar(255)                                                                                                                                                                                                                                                                                                                                                                not null,
     consume_goal             enum ('CLOTHING_UNDER_100K', 'COMPARE_BEFORE_BUYING', 'HAS_HOUSING_SAVING', 'INCOME_OVER_EXPENSE', 'LIMIT_DAILY_MEAL', 'MEAL_UNDER_20K', 'NO_EXPENSIVE_DESSERT', 'NO_OVER_50K_PER_DAY', 'NO_SPENDING_TODAY', 'NO_USELESS_ELECTRONICS', 'ONE_CATEGORY_SPEND', 'ONLY_PUBLIC_TRANSPORT', 'OVER_10_PERCENT', 'SAVE_70_PERCENT', 'SMALL_MONTHLY_SAVE', 'SUBSCRIPTION_UNDER_50K') null,
-    consumption_type         enum ('BALANCED', 'CONSERVATIVE', 'CONSUMPTION_ORIENTED', 'PRACTICAL') null,
-    last_login_method        enum ('PASSKEY', 'PASSWORD', 'SOCIAL') null,
-    role                     enum ('ADMIN', 'MEMBER') not null,
-    sex                      enum ('FEMALE', 'MALE') not null,
-    status                   enum ('ACTIVE', 'SUSPENDED', 'WITHDRAWN') not null
+    consumption_type         enum ('BALANCED', 'CONSERVATIVE', 'CONSUMPTION_ORIENTED', 'PRACTICAL')                                                                                                                                                                                                                                                                                                      null,
+    last_login_method        enum ('PASSKEY', 'PASSWORD', 'SOCIAL')                                                                                                                                                                                                                                                                                                                                      null,
+    role                     enum ('ADMIN', 'MEMBER')                                                                                                                                                                                                                                                                                                                                                    not null,
+    sex                      enum ('FEMALE', 'MALE')                                                                                                                                                                                                                                                                                                                                                     not null,
+    status                   enum ('ACTIVE', 'SUSPENDED', 'WITHDRAWN')                                                                                                                                                                                                                                                                                                                                   not null
+);
+
+-- MEMBER_CREDIT_SUMMARY (회원 신용정보 산정 이력)
+create table member_credit_summary
+(
+    id                         bigint auto_increment primary key,
+    member_id                  bigint       not null,
+    calculated_at              datetime(6)  not null default current_timestamp, -- 평가 시점
+    total_loan_count           int          not null default 0,                -- 보유 대출 건수
+    active_loan_count          int          not null default 0,                -- 현재 상환 중인 대출 건수
+    total_loan_balance         int          not null default 0,                -- 전체 대출 잔액
+    total_loan_overdue_30d     int          not null default 0,                -- 30일 이상 연체 건수
+    total_loan_overdue_90d     int          not null default 0,                -- 90일 이상 연체 건수
+    has_current_overdue        boolean      not null default false,            -- 현재 연체 여부
+    last_overdue_date          date         null,                              -- 최근 연체 발생일
+    comm_overdue_count         int          not null default 0,                -- 통신비 연체 건수
+    comm_overdue_max_days      int          not null default 0,                -- 통신비 최장 연체일수
+    utility_overdue_count      int          not null default 0,                -- 공과금 연체 건수
+    utility_overdue_max_days   int          not null default 0,                -- 공과금 최장 연체일수
+    credit_score               int          null,                              -- 신용점수(산정 결과)
+    interest_rate              float        null,                              -- 금리(산정 결과)
+    remark                     varchar(255) null,                              -- 비고
+    constraint FK_member_credit_summary_member foreign key (member_id) references member (member_id)
 );
 
 -- LOAN_PRODUCT (대출 상품)
@@ -55,13 +79,13 @@ create table loan_application
 -- FIDO_CREDENTIAL (패스키)
 create table fido_credential
 (
-    is_active      bit         not null,
-    sign_count     int         not null,
+    is_active      bit           not null,
+    sign_count     bigint        not null,
     credential_id  bigint auto_increment primary key,
-    last_used_date datetime(6) null,
-    member_id      bigint      not null,
-    device_info    varchar(20) not null,
-    public_key     varchar(50) not null,
+    last_used_date datetime(6)   null,
+    member_id      bigint        not null,
+    device_info    varchar(20)   not null,
+    public_key     varchar(1000) not null,
     constraint UKmsct6biuq32sdb2e8icuu4t68 unique (member_id),
     constraint FKs3bknrmcmske2xkvd96ga2myj foreign key (member_id) references member (member_id)
 );
@@ -83,16 +107,16 @@ create table loan_transaction
 -- MFA_LOG (다중 인증 로그)
 create table mfa_log
 (
-    authenticated_at datetime(6)                   not null,
+    authenticated_at datetime(6)                            not null,
     mfa_log_id       bigint auto_increment primary key,
-    transaction_id   bigint                        null,
-    device_info      varchar(20)                   null,
-    mfa_type         enum ('EMAIL', 'PASS', 'SMS') not null,
-    result           enum ('FAILURE', 'SUCCESS')   not null,
+    transaction_id   bigint                                 null,
+    device_info      varchar(20)                            null,
+    mfa_type         enum ('EMAIL', 'FIDO2', 'PASS', 'SMS') not null,
+    result           enum ('FAILURE', 'SUCCESS')            not null,
     constraint FKkytl8f2c6q4ry0eihdyvwn3k1 foreign key (transaction_id) references loan_transaction (transaction_id)
 );
 
--- INTEREST (대출 이자)
+-- INTEREST (변동 금리)
 create table interest
 (
     interest_rate  float       not null,
@@ -131,7 +155,7 @@ create table user_financial_data
     data_id      bigint auto_increment primary key,
     user_id      bigint                                                                                         not null,
     category     enum ('COMMUNICATION', 'EDUCATION', 'ETC', 'FOOD', 'HEALTH', 'LEISURE', 'LIVING', 'TRANSPORT') null,
-    data_type    enum ('EXPENSE', 'INCOME', 'LOAN_BALANCE')                                                     not null,
+    data_type    enum ('EXPENSE', 'INCOME')                                                     not null,
     constraint FKqk7w04q7gt20twv8xi8y17865 foreign key (user_id) references member (member_id)
 );
 
@@ -145,6 +169,17 @@ create table consumption_habit_report
     summary      varchar(500) null,
     constraint UK1n794ss5uofb3j16hsnj3l21e unique (member_id, report_month),
     constraint FKmq81atoh4ght2iogu5ouictrn foreign key (member_id) references member (member_id)
+);
+
+-- CONSUMPTION_HABIT_CATEGORY (소비 습관 카테고리)
+create table consumption_habit_category
+(
+    category_id   bigint auto_increment primary key,
+    report_id     bigint       not null,
+    category      enum ('COMMUNICATION', 'EDUCATION', 'ETC', 'FOOD', 'HEALTH', 'LEISURE', 'LIVING', 'TRANSPORT') not null,
+    amount        bigint       not null,
+    ratio         decimal(5,2) not null,
+    constraint FK_report_category foreign key (report_id) references consumption_habit_report (report_id) on delete cascade
 );
 
 -- AUDIT_LOG (감사 로그)
@@ -177,7 +212,6 @@ create table authentication
     auth_method      enum ('FIDO', 'MFA') null,
     constraint UK3hebrkl6ex5u6xv8wrj0m13mf unique (credential_id),
     constraint UKd3jsewxyq9sxygyaau5q46jcv unique (mfa_log_id),
-    constraint UKnrnmxpttm9vs0jaowf9m5jr5g unique (member_id),
     constraint FK2q7688loi42jwjgvh8q5s1te3 foreign key (credential_id) references fido_credential (credential_id),
     constraint FK8u5ywo54pknmfyi542m7ou80 foreign key (mfa_log_id) references mfa_log (mfa_log_id),
     constraint FKt8w1awoivi0ilqtrwqrjwq2s2 foreign key (member_id) references member (member_id)

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,184 @@
+-- MEMBER (회원)
+create table member
+(
+    birth_date               date null,
+    created_at               datetime(6) null,
+    last_login_at            datetime(6) null,
+    member_id                bigint auto_increment primary key,
+    password_last_changed_at datetime(6) null,
+    updated_at               datetime(6) null,
+    name                     varchar(20) not null,
+    phone                    varchar(20) null,
+    email                    varchar(50) not null,
+    password_hash            varchar(255) not null,
+    consume_goal             enum ('CLOTHING_UNDER_100K', 'COMPARE_BEFORE_BUYING', 'HAS_HOUSING_SAVING', 'INCOME_OVER_EXPENSE', 'LIMIT_DAILY_MEAL', 'MEAL_UNDER_20K', 'NO_EXPENSIVE_DESSERT', 'NO_OVER_50K_PER_DAY', 'NO_SPENDING_TODAY', 'NO_USELESS_ELECTRONICS', 'ONE_CATEGORY_SPEND', 'ONLY_PUBLIC_TRANSPORT', 'OVER_10_PERCENT', 'SAVE_70_PERCENT', 'SMALL_MONTHLY_SAVE', 'SUBSCRIPTION_UNDER_50K') null,
+    consumption_type         enum ('BALANCED', 'CONSERVATIVE', 'CONSUMPTION_ORIENTED', 'PRACTICAL') null,
+    last_login_method        enum ('PASSKEY', 'PASSWORD', 'SOCIAL') null,
+    role                     enum ('ADMIN', 'MEMBER') not null,
+    sex                      enum ('FEMALE', 'MALE') not null,
+    status                   enum ('ACTIVE', 'SUSPENDED', 'WITHDRAWN') not null
+);
+
+-- LOAN_PRODUCT (대출 상품)
+create table loan_product
+(
+    max_amount  int          not null,
+    max_rate    float        not null,
+    min_rate    float        not null,
+    terms       int          not null,
+    product_id  bigint auto_increment primary key,
+    name        varchar(20)  not null,
+    description varchar(255) not null
+);
+
+-- LOAN_APPLICATION (대출 신청)
+create table loan_application
+(
+    credit_score   int                                                                  not null,
+    rate           float                                                                not null,
+    remain_amount  int                                                                  not null,
+    total_amount   int                                                                  not null,
+    application_id bigint auto_increment primary key,
+    applied_at     datetime(6)                                                          null,
+    end_date       datetime(6)                                                          null,
+    executed_at    datetime(6)                                                          null,
+    member_id      bigint                                                               not null,
+    product_id     bigint                                                               null,
+    start_date     datetime(6)                                                          null,
+    loan_type      enum ('EXTENSION', 'NEW', 'REJOIN')                                  not null,
+    status         enum ('COMPLETED', 'EXECUTED', 'PENDING', 'PRE_APPLIED', 'REJECTED') not null,
+    constraint UKnu7i3b6jnfvmb18oufct4mbv0 unique (member_id),
+    constraint FKeewfg5rtu0ux0gv0n357t6g1v foreign key (member_id) references member (member_id),
+    constraint FKeyryxaov7qn04ctajae14l9sf foreign key (product_id) references loan_product (product_id)
+);
+
+-- FIDO_CREDENTIAL (패스키)
+create table fido_credential
+(
+    is_active      bit         not null,
+    sign_count     int         not null,
+    credential_id  bigint auto_increment primary key,
+    last_used_date datetime(6) null,
+    member_id      bigint      not null,
+    device_info    varchar(20) not null,
+    public_key     varchar(50) not null,
+    constraint UKmsct6biuq32sdb2e8icuu4t68 unique (member_id),
+    constraint FKs3bknrmcmske2xkvd96ga2myj foreign key (member_id) references member (member_id)
+);
+
+-- LOAN_TRANSACTION (대출 거래)
+create table loan_transaction
+(
+    amount         double                                   not null,
+    application_id bigint                                   not null,
+    member_id      bigint                                   not null,
+    occurred_at    datetime(6)                              not null,
+    transaction_id bigint auto_increment primary key,
+    status         enum ('CANCELLED', 'FAILED', 'NORMAL')   not null,
+    type           enum ('DELAY', 'EXECUTION', 'REPAYMENT') not null,
+    constraint FK8gityivfar00t9fc7lgyqx0s foreign key (member_id) references member (member_id),
+    constraint FKntk7t4npuvm0ryaq2wl32514w foreign key (application_id) references loan_application (application_id)
+);
+
+-- MFA_LOG (다중 인증 로그)
+create table mfa_log
+(
+    authenticated_at datetime(6)                   not null,
+    mfa_log_id       bigint auto_increment primary key,
+    transaction_id   bigint                        null,
+    device_info      varchar(20)                   null,
+    mfa_type         enum ('EMAIL', 'PASS', 'SMS') not null,
+    result           enum ('FAILURE', 'SUCCESS')   not null,
+    constraint FKkytl8f2c6q4ry0eihdyvwn3k1 foreign key (transaction_id) references loan_transaction (transaction_id)
+);
+
+-- INTEREST (대출 이자)
+create table interest
+(
+    interest_rate  float       not null,
+    application_id bigint      not null,
+    interest_date  datetime(6) not null,
+    interest_id    bigint auto_increment primary key,
+    constraint FK71miynswoeucff7manm0xth9g foreign key (application_id) references loan_application (application_id)
+);
+
+-- NOTIFICATION (알림)
+create table notification
+(
+    is_read         bit                                       not null,
+    member_id       bigint                                    not null,
+    notification_id bigint auto_increment primary key,
+    sent_at         datetime(6)                               not null,
+    content         varchar(50)                               not null,
+    type            enum ('LOAN_APPROVAL', 'MATURITY_NOTICE', 'INTEREST_RATE_CHANGE') not null,
+    constraint FK1xep8o2ge7if6diclyyx53v4q foreign key (member_id) references member (member_id)
+);
+
+-- REFRESH_TOKEN (리프레시 토큰)
+create table refresh_token
+(
+    id            bigint auto_increment primary key,
+    member_id     bigint       not null,
+    refresh_token varchar(255) not null,
+    constraint UKdnbbikqdsc2r2cee1afysqfk9 unique (member_id)
+);
+
+-- USER_FINANCIAL_DATA (유저 재무 데이터)
+create table user_financial_data
+(
+    value        int                                                                                            not null,
+    collected_at datetime(6)                                                                                    not null,
+    data_id      bigint auto_increment primary key,
+    user_id      bigint                                                                                         not null,
+    category     enum ('COMMUNICATION', 'EDUCATION', 'ETC', 'FOOD', 'HEALTH', 'LEISURE', 'LIVING', 'TRANSPORT') null,
+    data_type    enum ('EXPENSE', 'INCOME', 'LOAN_BALANCE')                                                     not null,
+    constraint FKqk7w04q7gt20twv8xi8y17865 foreign key (user_id) references member (member_id)
+);
+
+-- CONSUMPTION_HABIT_REPORT (소비 습관 리포트)
+create table consumption_habit_report
+(
+    created_at   date         not null,
+    report_month varchar(7)   not null,
+    member_id    bigint       not null,
+    report_id    bigint auto_increment primary key,
+    summary      varchar(500) null,
+    constraint UK1n794ss5uofb3j16hsnj3l21e unique (member_id, report_month),
+    constraint FKmq81atoh4ght2iogu5ouictrn foreign key (member_id) references member (member_id)
+);
+
+-- AUDIT_LOG (감사 로그)
+create table audit_log
+(
+    auth_method tinyint      null,
+    event_type  tinyint      null,
+    log_id      bigint auto_increment primary key,
+    member_id   bigint       null,
+    occurred_at datetime(6)  not null,
+    ip_address  varchar(50)  null,
+    device_info varchar(100) null,
+    action      varchar(255) not null,
+    detail      varchar(255) null,
+    constraint FK5bcyk09s5o5ss2oag9kbcrvha foreign key (member_id) references member (member_id),
+    check (`auth_method` between 0 and 1),
+    check (`event_type` between 0 and 2)
+);
+
+-- AUTHENTICATION (인증)
+create table authentication
+(
+    auth_id          bigint auto_increment primary key,
+    authenticated_at datetime(6)          null,
+    credential_id    bigint               null,
+    member_id        bigint               not null,
+    mfa_log_id       bigint               null,
+    ip_address       varchar(20)          null,
+    device_info      varchar(100)         null,
+    auth_method      enum ('FIDO', 'MFA') null,
+    constraint UK3hebrkl6ex5u6xv8wrj0m13mf unique (credential_id),
+    constraint UKd3jsewxyq9sxygyaau5q46jcv unique (mfa_log_id),
+    constraint UKnrnmxpttm9vs0jaowf9m5jr5g unique (member_id),
+    constraint FK2q7688loi42jwjgvh8q5s1te3 foreign key (credential_id) references fido_credential (credential_id),
+    constraint FK8u5ywo54pknmfyi542m7ou80 foreign key (mfa_log_id) references mfa_log (mfa_log_id),
+    constraint FKt8w1awoivi0ilqtrwqrjwq2s2 foreign key (member_id) references member (member_id)
+);

--- a/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
+++ b/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
@@ -1,0 +1,134 @@
+-- MEMBER (member 4, admin 1)
+insert into member (birth_date, created_at, last_login_at, password_last_changed_at, updated_at, name, phone, email, password_hash, consume_goal, consumption_type, last_login_method, role, sex, status)
+values
+    ('1988-03-03', now(), now(), now(), now(), '관리자', '010-0000-0000', 'admin@email.com', '$2a$12$4HKfRhCR/uYPitv3qL6HcecOGNNv14D6ou56iLl54nCwcJoR69u.G', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'PASSWORD', 'ADMIN', 'MALE', 'SUSPENDED'),
+    ('1995-01-01', now(), now(), now(), now(), '홍길동', '010-1111-1111', 'member1@email.com', '$2a$10$576ZiPjvVCKQKUR8Zcpt0.sIQEwz8T8Ys4dKmAFSDGYOKjQvcx1fy', 'ONE_CATEGORY_SPEND', 'BALANCED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    ('1992-02-02', now(), now(), now(), now(), '김영희', '010-2222-2222', 'member2@email.com', '$2a$10$w41NWOew7tkaU3lJUIA1YunUuTJbyXVXLBGE47iYgBBOiFs4ftxwO', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    ('2000-04-04', now(), now(), now(), now(), '박민정', '010-3333-3333', 'member3@email.com', '$2a$10$SOjqGxrZhaQT8Kg4.Eh3wOTLYPlcJhClJ4Dxm72O781zS.Dm.seF2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'WITHDRAWN'),
+    ('1998-05-05', now(), now(), now(), now(), '이수진', '010-4444-4444', 'member4@email.com', '$2a$10$X.1bheS9oo7BJJbs6q0cTuGEdNnUsJhY.lR645Kj24oowXNN9xGA.', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE');
+
+-- LOAN_PRODUCT (대출 상품)
+insert into loan_product (max_amount, max_rate, min_rate, terms, name, description)
+values (10000000, 8.5, 3.5, 36, '플렉스레이트', '유연한 상환이 가능한 대표 대출 상품');
+
+-- LOAN_APPLICATION (대출 신청)
+insert into loan_application (credit_score, rate, remain_amount, total_amount, member_id, product_id, loan_type, status, applied_at, start_date, end_date, executed_at)
+values
+    (800, 5.0, 3000000, 5000000, 2, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 12 month), date_sub(now(), interval 12 month), date_add(now(), interval 24 month), date_sub(now(), interval 11 month)),
+    (750, 4.5, 0, 3000000, 3, 1, 'EXTENSION', 'COMPLETED', date_sub(now(), interval 24 month), date_sub(now(), interval 24 month), date_sub(now(), interval 12 month), date_sub(now(), interval 23 month)),
+    (720, 7.8, 1500000, 4000000, 4, 1, 'NEW', 'PENDING', date_sub(now(), interval 3 month), null, null, null),
+    (810, 3.9, 2000000, 2000000, 5, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 1 month), date_sub(now(), interval 1 month), date_add(now(), interval 35 month), date_sub(now(), interval 1 month));
+
+-- FIDO_CREDENTIAL
+insert into fido_credential (is_active, sign_count, member_id, device_info, public_key, last_used_date)
+values
+    (1, 10, 2, 'Chrome-Win', 'pk1', date_sub(now(), interval 1 day)),
+    (1, 5, 3, 'Safari-iOS', 'pk2', date_sub(now(), interval 3 day)),
+    (0, 20, 4, 'Edge-Win', 'pk3', date_sub(now(), interval 10 day)),
+    (1, 15, 5, 'Firefox-Mac', 'pk4', date_sub(now(), interval 5 day));
+
+-- LOAN_TRANSACTION
+insert into loan_transaction (amount, application_id, member_id, occurred_at, status, type)
+values
+    (2000000, 1, 2, date_sub(now(), interval 30 day), 'NORMAL', 'DELAY'),
+    (500000, 1, 2, date_sub(now(), interval 25 day), 'NORMAL', 'REPAYMENT'),
+    (1000000, 2, 3, date_sub(now(), interval 20 day), 'NORMAL', 'EXECUTION'),
+    (300000, 2, 3, date_sub(now(), interval 15 day), 'NORMAL', 'REPAYMENT'),
+    (1500000, 2, 3, date_sub(now(), interval 10 day), 'NORMAL', 'EXECUTION'),
+    (2000000, 4, 5, date_sub(now(), interval 5 day), 'FAILED', 'EXECUTION');
+
+-- MFA_LOG
+insert into mfa_log (authenticated_at, mfa_type, result, device_info, transaction_id)
+values
+    (date_sub(now(), interval 10 day), 'SMS', 'SUCCESS', 'Galaxy S22', 1),
+    (date_sub(now(), interval 8 day), 'EMAIL', 'FAILURE', 'iPhone 14', 2),
+    (date_sub(now(), interval 6 day), 'PASS', 'SUCCESS', 'PC', 3),
+    (date_sub(now(), interval 4 day), 'SMS', 'FAILURE', 'iPad', 4),
+    (date_sub(now(), interval 2 day), 'EMAIL', 'SUCCESS', 'Macbook', 5);
+
+-- INTEREST
+insert into interest (interest_rate, application_id, interest_date)
+values
+    (5.0, 1, date_sub(now(), interval 5 day)),
+    (4.9, 1, date_sub(now(), interval 4 day)),
+    (4.8, 1, date_sub(now(), interval 3 day)),
+    (4.7, 1, date_sub(now(), interval 2 day)),
+    (4.6, 1, date_sub(now(), interval 1 day)),
+    (4.5, 2, date_sub(now(), interval 5 day)),
+    (4.4, 2, date_sub(now(), interval 4 day)),
+    (4.3, 2, date_sub(now(), interval 3 day)),
+    (4.2, 2, date_sub(now(), interval 2 day)),
+    (4.1, 2, date_sub(now(), interval 1 day)),
+    (4.0, 4, date_sub(now(), interval 5 day)),
+    (3.9, 4, date_sub(now(), interval 4 day)),
+    (3.8, 4, date_sub(now(), interval 3 day)),
+    (3.7, 4, date_sub(now(), interval 2 day)),
+    (3.6, 4, date_sub(now(), interval 1 day));
+
+
+-- NOTIFICATION
+insert into notification (is_read, member_id, sent_at, content, type)
+values
+    (0, 2, date_sub(now(), interval 5 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+    (1, 3, date_sub(now(), interval 4 day), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+    (0, 4, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+    (1, 5, date_sub(now(), interval 2 day), '만기 알림입니다.', 'MATURITY_NOTICE');
+
+-- REFRESH_TOKEN
+insert into refresh_token (member_id, refresh_token)
+values
+    (1, 'refresh_token_1'),
+    (2, 'refresh_token_2'),
+    (3, 'refresh_token_3');
+
+-- USER_FINANCIAL_DATA
+insert into user_financial_data (value, collected_at, user_id, category, data_type)
+values
+    (30000, date_sub(now(), interval 1 day), 2, 'FOOD', 'EXPENSE'),
+    (50000, date_sub(now(), interval 1 day), 2, 'TRANSPORT', 'EXPENSE'),
+    (100000, date_sub(now(), interval 1 day), 2, 'COMMUNICATION', 'EXPENSE'),
+    (20000, date_sub(now(), interval 1 day), 2, 'EDUCATION', 'EXPENSE'),
+    (50000, date_sub(now(), interval 1 day), 2, 'HEALTH', 'EXPENSE'),
+    (1000000, date_sub(now(), interval 1 month), 2, 'ETC', 'INCOME'),
+    (50000, date_sub(now(), interval 1 day), 3, 'FOOD', 'EXPENSE'),
+    (70000, date_sub(now(), interval 1 day), 3, 'TRANSPORT', 'EXPENSE'),
+    (120000, date_sub(now(), interval 1 day), 3, 'COMMUNICATION', 'EXPENSE'),
+    (30000, date_sub(now(), interval 1 day), 3, 'EDUCATION', 'EXPENSE'),
+    (60000, date_sub(now(), interval 1 day), 3, 'HEALTH', 'EXPENSE'),
+    (1500000, date_sub(now(), interval 1 month), 3, 'ETC', 'INCOME'),
+    (20000, date_sub(now(), interval 1 day), 4, 'FOOD', 'EXPENSE'),
+    (30000, date_sub(now(), interval 1 day), 4, 'TRANSPORT', 'EXPENSE'),
+    (50000, date_sub(now(), interval 1 day), 4, 'COMMUNICATION', 'EXPENSE'),
+    (10000, date_sub(now(), interval 1 day), 4, 'EDUCATION', 'EXPENSE'),
+    (20000, date_sub(now(), interval 1 day), 4, 'HEALTH', 'EXPENSE'),
+    (500000, date_sub(now(), interval 1 month), 4, 'ETC', 'INCOME'),
+    (100000, date_sub(now(), interval 1 day), 5, 'FOOD', 'EXPENSE'),
+    (150000, date_sub(now(), interval 1 day), 5, 'TRANSPORT', 'EXPENSE'),
+    (250000, date_sub(now(), interval 1 day), 5, 'COMMUNICATION', 'EXPENSE'),
+    (50000, date_sub(now(), interval 1 day), 5, 'EDUCATION', 'EXPENSE'),
+    (100000, date_sub(now(), interval 1 day), 5, 'HEALTH', 'EXPENSE'),
+    (150000, date_sub(now(), interval 1 day), 3, 'LEISURE', 'EXPENSE'),
+    (250000, date_sub(now(), interval 1 day), 4, 'EDUCATION', 'EXPENSE'),
+    (120000, date_sub(now(), interval 1 day), 5, 'COMMUNICATION', 'EXPENSE'),
+    (2000000, date_sub(now(), interval 1 month), 2, 'ETC', 'INCOME');
+
+-- CONSUMPTION_HABIT_REPORT
+insert into consumption_habit_report (created_at, report_month, member_id, summary)
+values
+    (date_add(now(), interval -7 day), '2024-05', 1, '지출이 꾸준히 감소했습니다.'),
+    (date_add(now(), interval -37 day), '2024-04', 2, '소비 패턴이 안정적입니다.'),
+    (date_add(now(), interval -67 day), '2024-03', 3, '저축 비율이 높아졌습니다.');
+
+-- AUDIT_LOG
+insert into audit_log (auth_method, event_type, member_id, occurred_at, ip_address, device_info, action, detail)
+values
+    (0, 1, 2, now(), '192.168.0.1', 'Chrome-Win', '로그인', '정상 로그인'),
+    (1, 2, 3, now(), '192.168.0.2', 'Safari-iOS', '비밀번호 변경', '비밀번호 변경 성공'),
+    (0, 0, 4, now(), '192.168.0.3', 'Edge-Win', '로그아웃', '정상 로그아웃');
+
+-- AUTHENTICATION
+insert into authentication (authenticated_at, credential_id, member_id, mfa_log_id, ip_address, device_info, auth_method)
+values
+    (now(), 1, 1, 1, '192.168.0.1', 'Chrome-Win', 'FIDO'),
+    (now(), 2, 2, 2, '192.168.0.2', 'Safari-iOS', 'FIDO'),
+    (now(), 3, 3, 3, '192.168.0.3', 'Edge-Win', 'FIDO');

--- a/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
+++ b/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
@@ -1,85 +1,275 @@
--- MEMBER (member 4, admin 1)
-insert into member (birth_date, created_at, last_login_at, password_last_changed_at, updated_at, name, phone, email, password_hash, consume_goal, consumption_type, last_login_method, role, sex, status)
+-- MEMBER (member 33, admin 1)
+insert into member(age, birth_date, created_at, last_login_at, password_last_changed_at, updated_at, name, phone, email, password_hash, consume_goal, consumption_type, last_login_method, role, sex, status)
 values
-    ('1988-03-03', now(), now(), now(), now(), '관리자', '010-0000-0000', 'admin@email.com', '$2a$12$4HKfRhCR/uYPitv3qL6HcecOGNNv14D6ou56iLl54nCwcJoR69u.G', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'PASSWORD', 'ADMIN', 'MALE', 'SUSPENDED'),
-    ('1995-01-01', now(), now(), now(), now(), '홍길동', '010-1111-1111', 'member1@email.com', '$2a$10$576ZiPjvVCKQKUR8Zcpt0.sIQEwz8T8Ys4dKmAFSDGYOKjQvcx1fy', 'ONE_CATEGORY_SPEND', 'BALANCED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
-    ('1992-02-02', now(), now(), now(), now(), '김영희', '010-2222-2222', 'member2@email.com', '$2a$10$w41NWOew7tkaU3lJUIA1YunUuTJbyXVXLBGE47iYgBBOiFs4ftxwO', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    ('2000-04-04', now(), now(), now(), now(), '박민정', '010-3333-3333', 'member3@email.com', '$2a$10$SOjqGxrZhaQT8Kg4.Eh3wOTLYPlcJhClJ4Dxm72O781zS.Dm.seF2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'WITHDRAWN'),
-    ('1998-05-05', now(), now(), now(), now(), '이수진', '010-4444-4444', 'member4@email.com', '$2a$10$X.1bheS9oo7BJJbs6q0cTuGEdNnUsJhY.lR645Kj24oowXNN9xGA.', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE');
+    -- ADMIN
+    (null, '1988-03-03', now(6), now(6), now(6), now(6), '관리자', '010-0000-0000', 'admin@email.com', '$2a$12$BBE6HrevyW5y6tMmgoLmyes2D.jIHdjeFK99YQ3ozo8gyZ9LLbozy', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSWORD', 'ADMIN', 'MALE', 'SUSPENDED'),
+
+    -- CONSERVATIVE (4)
+    (null, '1992-02-02', now(6), now(6), now(6), now(6), '김영희', '010-2222-2222', 'member2@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1990-01-10', now(6), now(6), now(6), now(6), '최성민', '010-5555-5555', 'member5@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'LIMIT_DAILY_MEAL', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1987-07-17', now(6), now(6), now(6), now(6), '박서진', '010-6666-6666', 'member6@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SAVE_70_PERCENT', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1985-12-05', now(6), now(6), now(6), now(6), '이진우', '010-7777-7777', 'member7@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'INCOME_OVER_EXPENSE', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+
+    -- PRACTICAL (4)
+    (null, '1989-08-08', now(6), now(6), now(6), now(6), '정하늘', '010-8888-8888', 'member8@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'COMPARE_BEFORE_BUYING', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1991-09-09', now(6), now(6), now(6), now(6), '윤지훈', '010-9999-9999', 'member9@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1993-03-03', now(6), now(6), now(6), now(6), '한유진', '010-1010-1010', 'member10@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'CLOTHING_UNDER_100K', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1986-06-06', now(6), now(6), now(6), now(6), '김태현', '010-1212-1212', 'member11@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+
+    -- BALANCED (4)
+    (null, '1995-01-01', now(6), now(6), now(6), now(6), '홍길동', '010-1111-1111', 'member1@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONE_CATEGORY_SPEND', 'BALANCED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1998-05-05', now(6), now(6), now(6), now(6), '이수진', '010-4444-4444', 'member4@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1994-04-14', now(6), now(6), now(6), now(6), '서지호', '010-1313-1313', 'member12@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_USELESS_ELECTRONICS', 'BALANCED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1996-06-16', now(6), now(6), now(6), now(6), '조민아', '010-1414-1414', 'member13@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'OVER_10_PERCENT', 'BALANCED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+
+    -- CONSUMPTION_ORIENTED (4)
+    (null, '2000-04-04', now(6), now(6), now(6), now(6), '박민정', '010-3333-3333', 'member3@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'WITHDRAWN'),
+    (null, '1997-07-07', now(6), now(6), now(6), now(6), '신동욱', '010-1515-1515', 'member14@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_OVER_50K_PER_DAY', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1999-09-09', now(6), now(6), now(6), now(6), '문지수', '010-1616-1616', 'member15@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SUBSCRIPTION_UNDER_50K', 'CONSUMPTION_ORIENTED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1993-12-12', now(6), now(6), now(6), now(6), '임채원', '010-1717-1717', 'member16@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'MEAL_UNDER_20K', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+
+    -- 나머지 멤버(랜덤 배치, 총 33명 맞추기 위해 17명 추가)
+    (null, '1990-02-10', now(6), now(6), now(6), now(6), '김도현', '010-1818-1818', 'member17@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1991-03-15', now(6), now(6), now(6), now(6), '이유림', '010-1919-1919', 'member18@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'LIMIT_DAILY_MEAL', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1992-04-20', now(6), now(6), now(6), now(6), '박은서', '010-2020-2020', 'member19@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SAVE_70_PERCENT', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1993-05-25', now(6), now(6), now(6), now(6), '최승훈', '010-2121-2121', 'member20@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'INCOME_OVER_EXPENSE', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1994-06-30', now(6), now(6), now(6), now(6), '정다은', '010-2222-2323', 'member21@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'COMPARE_BEFORE_BUYING', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1995-07-05', now(6), now(6), now(6), now(6), '한수빈', '010-2424-2424', 'member22@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1996-08-10', now(6), now(6), now(6), now(6), '서지훈', '010-2525-2525', 'member23@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'CLOTHING_UNDER_100K', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1997-09-15', now(6), now(6), now(6), now(6), '문예린', '010-2626-2626', 'member24@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '1998-10-20', now(6), now(6), now(6), now(6), '신유진', '010-2727-2727', 'member25@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONE_CATEGORY_SPEND', 'BALANCED', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '1999-11-25', now(6), now(6), now(6), now(6), '오지혁', '010-2828-2828', 'member26@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '2000-12-30', now(6), now(6), now(6), now(6), '이서준', '010-2929-2929', 'member27@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_USELESS_ELECTRONICS', 'BALANCED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '2001-01-04', now(6), now(6), now(6), now(6), '최지아', '010-3030-3030', 'member28@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'OVER_10_PERCENT', 'BALANCED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '2002-02-08', now(6), now(6), now(6), now(6), '임도윤', '010-3131-3131', 'member29@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '2003-03-12', now(6), now(6), now(6), now(6), '강지우', '010-3232-3232', 'member30@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_OVER_50K_PER_DAY', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '2004-04-16', now(6), now(6), now(6), now(6), '서하윤', '010-3333-3333', 'member31@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SUBSCRIPTION_UNDER_50K', 'CONSUMPTION_ORIENTED', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
+    (null, '2005-05-20', now(6), now(6), now(6), now(6), '박시윤', '010-3434-3434', 'member32@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'MEAL_UNDER_20K', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (null, '2006-06-24', now(6), now(6), now(6), now(6), '조하람', '010-3535-3535', 'member33@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE');
+
 
 -- LOAN_PRODUCT (대출 상품)
 insert into loan_product (max_amount, max_rate, min_rate, terms, name, description)
-values (10000000, 8.5, 3.5, 36, '플렉스레이트', '유연한 상환이 가능한 대표 대출 상품');
+values (10000000, 8.5, 3.5, 36, '플렉스레이트', '당신의 라이프스타일로 평가받는 신용대출');
 
 -- LOAN_APPLICATION (대출 신청)
-insert into loan_application (credit_score, rate, remain_amount, total_amount, member_id, product_id, loan_type, status, applied_at, start_date, end_date, executed_at)
+insert into loan_application
+(credit_score, rate, remain_amount, total_amount, member_id, product_id, loan_type, status, applied_at, start_date, end_date, executed_at)
 values
     (800, 5.0, 3000000, 5000000, 2, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 12 month), date_sub(now(), interval 12 month), date_add(now(), interval 24 month), date_sub(now(), interval 11 month)),
     (750, 4.5, 0, 3000000, 3, 1, 'EXTENSION', 'COMPLETED', date_sub(now(), interval 24 month), date_sub(now(), interval 24 month), date_sub(now(), interval 12 month), date_sub(now(), interval 23 month)),
-    (720, 7.8, 1500000, 4000000, 4, 1, 'NEW', 'PENDING', date_sub(now(), interval 3 month), null, null, null),
-    (810, 3.9, 2000000, 2000000, 5, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 1 month), date_sub(now(), interval 1 month), date_add(now(), interval 35 month), date_sub(now(), interval 1 month));
-
--- FIDO_CREDENTIAL
-insert into fido_credential (is_active, sign_count, member_id, device_info, public_key, last_used_date)
-values
-    (1, 10, 2, 'Chrome-Win', 'pk1', date_sub(now(), interval 1 day)),
-    (1, 5, 3, 'Safari-iOS', 'pk2', date_sub(now(), interval 3 day)),
-    (0, 20, 4, 'Edge-Win', 'pk3', date_sub(now(), interval 10 day)),
-    (1, 15, 5, 'Firefox-Mac', 'pk4', date_sub(now(), interval 5 day));
+    (720, 7.8, 4000000, 4000000, 4, 1, 'NEW', 'PENDING', date_sub(now(), interval 3 month), null, null, null),
+    (810, 3.9, 2000000, 2000000, 5, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 1 month), date_sub(now(), interval 1 month), date_add(now(), interval 35 month), date_sub(now(), interval 1 month)),
+    (690, 8.2, 2000000, 2000000, 6, 1, 'NEW', 'PENDING', date_sub(now(), interval 2 month), null, null, null),
+    (710, 6.5, 0, 1500000, 7, 1, 'REJOIN', 'REJECTED', date_sub(now(), interval 6 month), null, null, null),
+    (730, 4.7, 1200000, 3000000, 8, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 8 month), date_sub(now(), interval 8 month), date_add(now(), interval 28 month), date_sub(now(), interval 7 month)),
+    (820, 3.7, 0, 1000000, 9, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 36 month), date_sub(now(), interval 36 month), date_sub(now(), interval 0 month), date_sub(now(), interval 35 month)),
+    (735, 5.2, 800000, 2000000, 10, 1, 'EXTENSION', 'EXECUTED', date_sub(now(), interval 10 month), date_sub(now(), interval 10 month), date_add(now(), interval 26 month), date_sub(now(), interval 9 month)),
+    (700, 7.4, 0, 2500000, 11, 1, 'NEW', 'REJECTED', date_sub(now(), interval 5 month), null, null, null),
+    (780, 4.1, 400000, 1000000, 12, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 4 month), date_sub(now(), interval 4 month), date_add(now(), interval 32 month), date_sub(now(), interval 3 month)),
+    (765, 6.8, 0, 2200000, 13, 1, 'REJOIN', 'COMPLETED', date_sub(now(), interval 20 month), date_sub(now(), interval 20 month), date_sub(now(), interval 8 month), date_sub(now(), interval 19 month)),
+    (805, 3.5, 0, 500000, 14, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 13 month), date_sub(now(), interval 13 month), date_add(now(), interval 23 month), date_sub(now(), interval 12 month)),
+    (720, 7.1, 3000000, 3000000, 15, 1, 'NEW', 'PRE_APPLIED', date_sub(now(), interval 1 month), null, null, null),
+    (750, 5.8, 0, 1800000, 16, 1, 'NEW', 'REJECTED', date_sub(now(), interval 7 month), null, null, null),
+    (790, 4.2, 600000, 1200000, 17, 1, 'EXTENSION', 'EXECUTED', date_sub(now(), interval 15 month), date_sub(now(), interval 15 month), date_add(now(), interval 21 month), date_sub(now(), interval 14 month)),
+    (830, 3.8, 0, 700000, 18, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 18 month), date_sub(now(), interval 18 month), date_add(now(), interval 18 month), date_sub(now(), interval 17 month)),
+    (700, 8.0, 1300000, 3000000, 19, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 9 month), date_sub(now(), interval 9 month), date_add(now(), interval 27 month), date_sub(now(), interval 8 month)),
+    (695, 7.6, 0, 1200000, 20, 1, 'REJOIN', 'REJECTED', date_sub(now(), interval 11 month), null, null, null),
+    (780, 4.9, 900000, 2000000, 21, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 6 month), date_sub(now(), interval 6 month), date_add(now(), interval 30 month), date_sub(now(), interval 5 month)),
+    (760, 5.5, 0, 2500000, 22, 1, 'NEW', 'PENDING', date_sub(now(), interval 2 month), null, null, null),
+    (720, 7.0, 1100000, 2000000, 23, 1, 'EXTENSION', 'EXECUTED', date_sub(now(), interval 17 month), date_sub(now(), interval 17 month), date_add(now(), interval 19 month), date_sub(now(), interval 16 month)),
+    (815, 3.6, 0, 600000, 24, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 22 month), date_sub(now(), interval 22 month), date_add(now(), interval 14 month), date_sub(now(), interval 21 month)),
+    (740, 6.2, 100000, 1000000, 25, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 3 month), date_sub(now(), interval 3 month), date_add(now(), interval 33 month), date_sub(now(), interval 2 month)),
+    (700, 8.1, 0, 900000, 26, 1, 'REJOIN', 'REJECTED', date_sub(now(), interval 14 month), null, null, null),
+    (785, 4.6, 500000, 1500000, 27, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 7 month), date_sub(now(), interval 7 month), date_add(now(), interval 29 month), date_sub(now(), interval 6 month)),
+    (810, 3.9, 0, 800000, 28, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 25 month), date_sub(now(), interval 25 month), date_add(now(), interval 11 month), date_sub(now(), interval 24 month)),
+    (730, 6.9, 200000, 1200000, 29, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 5 month), date_sub(now(), interval 5 month), date_add(now(), interval 31 month), date_sub(now(), interval 4 month)),
+    (715, 7.3, 0, 1400000, 30, 1, 'EXTENSION', 'REJECTED', date_sub(now(), interval 16 month), null, null, null),
+    (805, 3.7, 0, 500000, 31, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 19 month), date_sub(now(), interval 19 month), date_add(now(), interval 17 month), date_sub(now(), interval 18 month)),
+    (690, 8.5, 1500000, 3500000, 32, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 2 month), date_sub(now(), interval 2 month), date_add(now(), interval 34 month), date_sub(now(), interval 1 month)),
+    (750, 5.9, 0, 2000000, 33, 1, 'REJOIN', 'PENDING', date_sub(now(), interval 1 month), null, null, null),
+    (820, 3.6, 0, 650000, 34, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 28 month), date_sub(now(), interval 28 month), date_add(now(), interval 8 month), date_sub(now(), interval 27 month)),
+    (740, 6.1, 600000, 1700000, 35, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 13 month), date_sub(now(), interval 13 month), date_add(now(), interval 23 month), date_sub(now(), interval 12 month));
 
 -- LOAN_TRANSACTION
 insert into loan_transaction (amount, application_id, member_id, occurred_at, status, type)
 values
-    (2000000, 1, 2, date_sub(now(), interval 30 day), 'NORMAL', 'DELAY'),
-    (500000, 1, 2, date_sub(now(), interval 25 day), 'NORMAL', 'REPAYMENT'),
-    (1000000, 2, 3, date_sub(now(), interval 20 day), 'NORMAL', 'EXECUTION'),
-    (300000, 2, 3, date_sub(now(), interval 15 day), 'NORMAL', 'REPAYMENT'),
-    (1500000, 2, 3, date_sub(now(), interval 10 day), 'NORMAL', 'EXECUTION'),
-    (2000000, 4, 5, date_sub(now(), interval 5 day), 'FAILED', 'EXECUTION');
+    -- application_id: 1, member_id: 2, 집행/상환/연체
+    (5000000, 1, 2, date_sub(now(), interval 11 month), 'NORMAL', 'EXECUTION'),
+    (1000000, 1, 2, date_sub(now(), interval 9 month), 'NORMAL', 'REPAYMENT'),
+    (1000000, 1, 2, date_sub(now(), interval 6 month), 'NORMAL', 'REPAYMENT'),
+    (1000000, 1, 2, date_sub(now(), interval 3 month), 'FAILED', 'DELAY'),
 
--- MFA_LOG
-insert into mfa_log (authenticated_at, mfa_type, result, device_info, transaction_id)
-values
-    (date_sub(now(), interval 10 day), 'SMS', 'SUCCESS', 'Galaxy S22', 1),
-    (date_sub(now(), interval 8 day), 'EMAIL', 'FAILURE', 'iPhone 14', 2),
-    (date_sub(now(), interval 6 day), 'PASS', 'SUCCESS', 'PC', 3),
-    (date_sub(now(), interval 4 day), 'SMS', 'FAILURE', 'iPad', 4),
-    (date_sub(now(), interval 2 day), 'EMAIL', 'SUCCESS', 'Macbook', 5);
+    -- application_id: 4, member_id: 5, 집행/상환
+    (2000000, 4, 5, date_sub(now(), interval 1 month), 'NORMAL', 'EXECUTION'),
+    (500000, 4, 5, date_sub(now(), interval 15 day), 'NORMAL', 'REPAYMENT'),
+
+    -- application_id: 7, member_id: 8, 집행/상환/연체
+    (3000000, 7, 8, date_sub(now(), interval 7 month), 'NORMAL', 'EXECUTION'),
+    (900000, 7, 8, date_sub(now(), interval 5 month), 'NORMAL', 'REPAYMENT'),
+    (900000, 7, 8, date_sub(now(), interval 2 month), 'FAILED', 'DELAY'),
+
+    -- application_id: 12, member_id: 17, 집행/상환
+    (1200000, 12, 17, date_sub(now(), interval 14 month), 'NORMAL', 'EXECUTION'),
+    (300000, 12, 17, date_sub(now(), interval 11 month), 'NORMAL', 'REPAYMENT'),
+
+    -- application_id: 16, member_id: 21, 집행/상환
+    (2000000, 16, 21, date_sub(now(), interval 5 month), 'NORMAL', 'EXECUTION'),
+    (700000, 16, 21, date_sub(now(), interval 3 month), 'NORMAL', 'REPAYMENT'),
+
+    -- application_id: 17, member_id: 19, 집행/상환/연체
+    (3000000, 17, 19, date_sub(now(), interval 8 month), 'NORMAL', 'EXECUTION'),
+    (1000000, 17, 19, date_sub(now(), interval 5 month), 'NORMAL', 'REPAYMENT'),
+    (700000, 17, 19, date_sub(now(), interval 2 month), 'FAILED', 'DELAY'),
+
+    -- application_id: 20, member_id: 23, 집행/상환
+    (2000000, 20, 23, date_sub(now(), interval 16 month), 'NORMAL', 'EXECUTION'),
+    (500000, 20, 23, date_sub(now(), interval 13 month), 'NORMAL', 'REPAYMENT'),
+
+    -- application_id: 22, member_id: 25, 집행/상환/연체
+    (1700000, 22, 35, date_sub(now(), interval 12 month), 'NORMAL', 'EXECUTION'),
+    (400000, 22, 35, date_sub(now(), interval 10 month), 'NORMAL', 'REPAYMENT'),
+    (300000, 22, 35, date_sub(now(), interval 2 month), 'FAILED', 'DELAY');
 
 -- INTEREST
 insert into interest (interest_rate, application_id, interest_date)
 values
-    (5.0, 1, date_sub(now(), interval 5 day)),
-    (4.9, 1, date_sub(now(), interval 4 day)),
-    (4.8, 1, date_sub(now(), interval 3 day)),
-    (4.7, 1, date_sub(now(), interval 2 day)),
-    (4.6, 1, date_sub(now(), interval 1 day)),
-    (4.5, 2, date_sub(now(), interval 5 day)),
-    (4.4, 2, date_sub(now(), interval 4 day)),
-    (4.3, 2, date_sub(now(), interval 3 day)),
-    (4.2, 2, date_sub(now(), interval 2 day)),
-    (4.1, 2, date_sub(now(), interval 1 day)),
-    (4.0, 4, date_sub(now(), interval 5 day)),
-    (3.9, 4, date_sub(now(), interval 4 day)),
-    (3.8, 4, date_sub(now(), interval 3 day)),
-    (3.7, 4, date_sub(now(), interval 2 day)),
-    (3.6, 4, date_sub(now(), interval 1 day));
+-- application_id: 1 (5.0% → 점진적 하락)
+(5.000, 1, date_sub(now(), interval 4 day)),
+(4.995, 1, date_sub(now(), interval 3 day)),
+(4.990, 1, date_sub(now(), interval 2 day)),
+(4.988, 1, date_sub(now(), interval 1 day)),
+(4.985, 1, now()),
 
+-- application_id: 4 (3.9% → 소폭 등락, 전체적 하락)
+(3.900, 4, date_sub(now(), interval 4 day)),
+(3.902, 4, date_sub(now(), interval 3 day)),
+(3.899, 4, date_sub(now(), interval 2 day)),
+(3.894, 4, date_sub(now(), interval 1 day)),
+(3.891, 4, now()),
+
+-- application_id: 7 (4.7% → 점진적 하락)
+(4.700, 7, date_sub(now(), interval 4 day)),
+(4.695, 7, date_sub(now(), interval 3 day)),
+(4.690, 7, date_sub(now(), interval 2 day)),
+(4.688, 7, date_sub(now(), interval 1 day)),
+(4.685, 7, now()),
+
+-- application_id: 10 (5.2% → 점진적 하락)
+(5.200, 10, date_sub(now(), interval 4 day)),
+(5.198, 10, date_sub(now(), interval 3 day)),
+(5.195, 10, date_sub(now(), interval 2 day)),
+(5.192, 10, date_sub(now(), interval 1 day)),
+(5.190, 10, now()),
+
+-- application_id: 12 (4.1% → 점진적 하락)
+(4.100, 12, date_sub(now(), interval 4 day)),
+(4.098, 12, date_sub(now(), interval 3 day)),
+(4.096, 12, date_sub(now(), interval 2 day)),
+(4.093, 12, date_sub(now(), interval 1 day)),
+(4.090, 12, now()),
+
+-- application_id: 17 (4.2% → 소폭 등락, 전체적 하락)
+(4.200, 17, date_sub(now(), interval 4 day)),
+(4.202, 17, date_sub(now(), interval 3 day)), -- 소폭 상승
+(4.198, 17, date_sub(now(), interval 2 day)),
+(4.194, 17, date_sub(now(), interval 1 day)),
+(4.191, 17, now()),
+
+-- application_id: 19 (8.0% → 점진적 하락)
+(8.000, 19, date_sub(now(), interval 4 day)),
+(7.995, 19, date_sub(now(), interval 3 day)),
+(7.990, 19, date_sub(now(), interval 2 day)),
+(7.988, 19, date_sub(now(), interval 1 day)),
+(7.985, 19, now()),
+
+-- application_id: 21 (4.9% → 점진적 하락)
+(4.900, 21, date_sub(now(), interval 4 day)),
+(4.897, 21, date_sub(now(), interval 3 day)),
+(4.895, 21, date_sub(now(), interval 2 day)),
+(4.892, 21, date_sub(now(), interval 1 day)),
+(4.890, 21, now()),
+
+-- application_id: 23 (7.0% → 점진적 하락)
+(7.000, 23, date_sub(now(), interval 4 day)),
+(6.995, 23, date_sub(now(), interval 3 day)),
+(6.990, 23, date_sub(now(), interval 2 day)),
+(6.988, 23, date_sub(now(), interval 1 day)),
+(6.985, 23, now()),
+
+-- application_id: 25 (6.2% → 소폭 등락, 전체적 하락)
+(6.200, 25, date_sub(now(), interval 4 day)),
+(6.202, 25, date_sub(now(), interval 3 day)), -- 소폭 상승
+(6.199, 25, date_sub(now(), interval 2 day)),
+(6.194, 25, date_sub(now(), interval 1 day)),
+(6.191, 25, now()),
+
+-- application_id: 27 (4.6% → 점진적 하락)
+(4.600, 27, date_sub(now(), interval 4 day)),
+(4.595, 27, date_sub(now(), interval 3 day)),
+(4.590, 27, date_sub(now(), interval 2 day)),
+(4.588, 27, date_sub(now(), interval 1 day)),
+(4.585, 27, now()),
+
+-- application_id: 29 (6.9% → 점진적 하락)
+(6.900, 29, date_sub(now(), interval 4 day)),
+(6.895, 29, date_sub(now(), interval 3 day)),
+(6.890, 29, date_sub(now(), interval 2 day)),
+(6.888, 29, date_sub(now(), interval 1 day)),
+(6.885, 29, now()),
+
+-- application_id: 32 (8.5% → 점진적 하락)
+(8.500, 32, date_sub(now(), interval 4 day)),
+(8.495, 32, date_sub(now(), interval 3 day)),
+(8.490, 32, date_sub(now(), interval 2 day)),
+(8.488, 32, date_sub(now(), interval 1 day)),
+(8.485, 32, now()),
+
+-- application_id: 35 (6.1% → 소폭 등락, 전체적 하락)
+(6.100, 35, date_sub(now(), interval 4 day)),
+(6.102, 35, date_sub(now(), interval 3 day)), -- 소폭 상승
+(6.099, 35, date_sub(now(), interval 2 day)),
+(6.094, 35, date_sub(now(), interval 1 day)),
+(6.091, 35, now());
 
 -- NOTIFICATION
 insert into notification (is_read, member_id, sent_at, content, type)
 values
-    (0, 2, date_sub(now(), interval 5 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
-    (1, 3, date_sub(now(), interval 4 day), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
-    (0, 4, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
-    (1, 5, date_sub(now(), interval 2 day), '만기 알림입니다.', 'MATURITY_NOTICE');
+-- 대출 승인 알림
+(0, 2, date_sub(now(), interval 12 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(1, 5, date_sub(now(), interval 1 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 8, date_sub(now(), interval 8 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 10, date_sub(now(), interval 10 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(1, 17, date_sub(now(), interval 4 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 19, date_sub(now(), interval 15 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 21, date_sub(now(), interval 9 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(1, 23, date_sub(now(), interval 6 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 25, date_sub(now(), interval 17 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 35, date_sub(now(), interval 3 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(1, 27, date_sub(now(), interval 7 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 29, date_sub(now(), interval 5 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(0, 32, date_sub(now(), interval 2 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(1, 35, date_sub(now(), interval 13 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 
--- REFRESH_TOKEN
-insert into refresh_token (member_id, refresh_token)
-values
-    (1, 'refresh_token_1'),
-    (2, 'refresh_token_2'),
-    (3, 'refresh_token_3');
+-- 금리 변동 알림
+(0, 2, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(1, 5, date_sub(now(), interval 1 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 8, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 10, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 17, date_sub(now(), interval 4 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(1, 19, date_sub(now(), interval 1 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 21, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 23, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(1, 25, date_sub(now(), interval 1 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 35, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 27, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(1, 29, date_sub(now(), interval 1 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 32, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+(0, 35, date_sub(now(), interval 4 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
+
+-- 만기 알림 (start_date + 11개월, 만기 7일 전)
+(0, 2, date_add(date_sub(now(), interval 12 month), interval 11 month), '대출 만기 7일 전입니다.', 'MATURITY_NOTICE'),
+(1, 5, date_add(date_sub(now(), interval 1 month), interval 11 month), '대출 만기 7일 전입니다.', 'MATURITY_NOTICE');
 
 -- USER_FINANCIAL_DATA
 insert into user_financial_data (value, collected_at, user_id, category, data_type)
@@ -115,9 +305,42 @@ values
 -- CONSUMPTION_HABIT_REPORT
 insert into consumption_habit_report (created_at, report_month, member_id, summary)
 values
-    (date_sub(now(), interval 7 day), '2024-05', 1, '지출이 꾸준히 감소했습니다.'),
-    (date_sub(now(), interval 37 day), '2024-04', 2, '소비 패턴이 안정적입니다.'),
-    (date_sub(now(), interval 67 day), '2024-03', 3, '저축 비율이 높아졌습니다.');
+    (date_sub(now(), interval 7 day), '2024-05', 1, '최근 소비 내용을 살펴보면, 꼭 필요한 생활비와 자기계발에 균형 있게 지출하고 계신 모습이 인상적이에요. 특히 자기계발에 투자하는 비율이 높아서, 단순한 소비보다는 앞으로를 위한 사용에 가치를 두고 계시다는 느낌이 들어요! 다만 가끔 외식이나 취미 쪽에서 예산보다 조금 더 쓰는 경향이 보이는데요, 이런 부분은 월초에 ‘자유롭게 써도 되는 예산’을 따로 정해두면 마음도 편하고 소비 후 아쉬움도 덜 수 있을 것 같아요. 지금처럼 균형 있는 소비를 유지하신다면 앞으로도 큰 걱정 없이 잘 관리해나가실 수 있을 거예요!'),
+    (date_sub(now(), interval 37 day), '2024-04', 2, '교통비와 식비 비중이 높게 나타났어요. 이동이 잦았던 만큼, 평소보다 교통비가 많이 들었네요.'),
+    (date_sub(now(), interval 67 day), '2024-03', 3, '건강 관리에 대한 지출이 꾸준히 유지되고 있습니다. 식비와 여가비도 적절하게 분배되어 있어요.');
+
+-- report_id = 1 (2024-05, member_id=1)
+insert into consumption_habit_category (report_id, category, amount, ratio) values
+    (1, 'FOOD', 90000, 30.00),
+    (1, 'EDUCATION', 80000, 26.67),
+    (1, 'LEISURE', 60000, 20.00),
+    (1, 'COMMUNICATION', 30000, 10.00),
+    (1, 'TRANSPORT', 20000, 6.67),
+    (1, 'HEALTH', 10000, 3.33),
+    (1, 'ETC', 5000, 1.67),
+    (1, 'LIVING', 5000, 1.66);
+
+-- report_id = 2 (2024-04, member_id=2)
+insert into consumption_habit_category (report_id, category, amount, ratio) values
+     (2, 'TRANSPORT', 60000, 30.00),
+     (2, 'FOOD', 55000, 27.50),
+     (2, 'LIVING', 30000, 15.00),
+     (2, 'COMMUNICATION', 20000, 10.00),
+     (2, 'LEISURE', 15000, 7.50),
+     (2, 'HEALTH', 10000, 5.00),
+     (2, 'ETC', 5000, 2.50),
+     (2, 'EDUCATION', 5000, 2.50);
+
+-- report_id = 3 (2024-03, member_id=3)
+insert into consumption_habit_category (report_id, category, amount, ratio) values
+     (3, 'HEALTH', 50000, 25.00),
+     (3, 'FOOD', 50000, 25.00),
+     (3, 'LEISURE', 40000, 20.00),
+     (3, 'LIVING', 20000, 10.00),
+     (3, 'COMMUNICATION', 15000, 7.50),
+     (3, 'TRANSPORT', 10000, 5.00),
+     (3, 'EDUCATION', 7500, 3.75),
+     (3, 'ETC', 2500, 1.25);
 
 -- AUDIT_LOG
 insert into audit_log (auth_method, event_type, member_id, occurred_at, ip_address, device_info, action, detail)

--- a/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
+++ b/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
@@ -115,9 +115,9 @@ values
 -- CONSUMPTION_HABIT_REPORT
 insert into consumption_habit_report (created_at, report_month, member_id, summary)
 values
-    (date_add(now(), interval -7 day), '2024-05', 1, '지출이 꾸준히 감소했습니다.'),
-    (date_add(now(), interval -37 day), '2024-04', 2, '소비 패턴이 안정적입니다.'),
-    (date_add(now(), interval -67 day), '2024-03', 3, '저축 비율이 높아졌습니다.');
+    (date_sub(now(), interval 7 day), '2024-05', 1, '지출이 꾸준히 감소했습니다.'),
+    (date_sub(now(), interval 37 day), '2024-04', 2, '소비 패턴이 안정적입니다.'),
+    (date_sub(now(), interval 67 day), '2024-03', 3, '저축 비율이 높아졌습니다.');
 
 -- AUDIT_LOG
 insert into audit_log (auth_method, event_type, member_id, occurred_at, ip_address, device_info, action, detail)


### PR DESCRIPTION
## 🔥 Related Issues

- close #65 

## 💜 작업 내용

- [x] NotificationType에 INTEREST_RATE_CHANGE 추가 (금리 변동 알림) 
- [x] application.yml, application-prod.yml ddl-auto를 `validate`로 변경 (flyway 적용을 위해)
- [x] 초기 DDL 작성 (V1__init.sql)
- [x] 개발 및 테스트를 위한 더미 데이터 마이그레이션 스크립트 추가 (V999__init_dev_dummy_data.sql)

## ✅ PR Point

- **application.yml, application-prod.yml ddl-auto를 `validate`로 변경**  
  ddl-auto는 validate 또는 none으로 고정하고 사용하셔야 JPA가 임의로 테이블을 생성/수정하지 않고, Flyway 마이그레이션만을 통해 스키마 변경을 관리해줄 수 있습니다.

- 더미 데이터가 적절한지 확인해주시고, 추가 또는 개선하고싶은 데이터가있다면 말씀해주세요.


## ⭐ pull 받고 반드시!!!!!! 해야할 설정 (안하면 오류나요 😆)
1) springboot는 "중지"상태에서, 도커 데이터베이스 콘솔에 진입해서 아래 명령어를 순서대로 입력
> mysql -u flexrate_user -p{flexrate DB 비밀번호}
> DROP DATABASE flexrate;
> CREATE DATABASE flexrate;
<img width="584" alt="스크린샷 2025-05-09 17 54 16" src="https://github.com/user-attachments/assets/b4eded4a-ceac-4f64-b6a1-f2856d931e9e" />

2) application.yml ddl-auto 확인
ddl-auto가 `none` 또는 `validate` 인지 확인.
- none: 아무런 작업도 하지 않음
- validate: 엔티티 클래스와 실제 DB 테이블의 구조가 일치하는지 검증
=> DDL 작업을 JPA가 아닌 flyway에게 위임하기 위함

3) springboot 재시작

4) 더미 데이터가 잘 들어가있는지 확인
`select * from member;`
등 아무 테이블이나 확인해서 데이터 들어와있으면 확인 완료

## 😡 Trouble Shooting

Flyway 마이그레이션(V1__init.sql)에서 외래키 참조 오류(`Failed to open the referenced table 'loan_transaction'`, MySQL 1824 에러)가 발생했습니다.  
외래키로 참조하는 테이블이 아직 생성되지 않은 상태에서, 참조하는 테이블을 먼저 생성하려 했기 때문에 발생했던 오류였습니다.
따라서 테이블 생성 순서를 재조정하여, 외래키로 참조되는 테이블(loan_transaction)을 먼저 생성하도록 스크립트를 수정했습니다.
필요시 모든 테이블 생성 후 ALTER TABLE로 외래키를 추가하는 방법도 적용할 수 있음을 확인했습니다.


## ☀ 스크린샷 / GIF / 화면 녹화
### 첫 실행시 모든 테이블에 더미데이터가 삽입됩니다.
![스크린샷 2025-05-09 17 48 51](https://github.com/user-attachments/assets/929a37f1-07c6-447a-9b10-dea692401acd)

