### PR TITLE
fix: 고객 리스트 조회 API 개선

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -46,9 +46,13 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
         if (request.sex() != null) {
             builder.and(member.sex.eq(request.sex()));
         }
-        if (request.birthDate() != null) {
-            builder.and(member.birthDate.eq(request.birthDate()));
+        if (request.birthDateStart() != null) {
+            builder.and(member.birthDate.goe(request.birthDateStart()));
         }
+        if (request.birthDateEnd() != null) {
+            builder.and(member.birthDate.loe(request.birthDateEnd()));
+        }
+
         if (request.memberStatus() != null) {
             builder.and(member.status.eq(request.memberStatus()));
         }
@@ -72,16 +76,14 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
             }
         }
 
-        // loanTransactionCount 조건
-        if (request.loanTransactionCount() != null) {
-            if (request.loanTransactionCount() == 0) {
-                builder.and(member.loanApplication.isNull());
-            } else {
-                builder.and(
-                        member.loanApplication.isNotNull()
-                                .and(member.loanApplication.loanTransactions.size().eq(request.loanTransactionCount()))
-                );
-            }
+        // loanTransactionCount(거래 횟수) 조건
+        if (request.transactionCountMin() != null) {
+            builder.and(member.loanApplication.isNotNull()
+                    .and(member.loanApplication.loanTransactions.size().goe(request.transactionCountMin())));
+        }
+        if (request.transactionCountMax() != null) {
+            builder.and(member.loanApplication.isNotNull()
+                    .and(member.loanApplication.loanTransactions.size().loe(request.transactionCountMax())));
         }
 
         List<Member> members = queryFactory.selectFrom(member)

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
@@ -27,6 +27,7 @@ public record MemberSearchRequest(
 
         @Min(value = 0, message = "거래 내역 횟수는 0 이상이어야 합니다.")
         Integer transactionCountMin,
+        @Min(value = 0, message = "거래 내역 횟수는 0 이상이어야 합니다.")
         Integer transactionCountMax,
 
         @Min(value = 0, message = "페이지는 0 이상이어야 합니다.")

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/MemberSearchRequest.java
@@ -16,14 +16,18 @@ public record MemberSearchRequest(
         String email,
 
         Sex sex,
-        LocalDate birthDate,
+        LocalDate birthDateStart,
+        LocalDate birthDateEnd,
+
         MemberStatus memberStatus,
         LocalDate startDate,
         LocalDate endDate,
+
         Boolean hasLoan,
 
         @Min(value = 0, message = "거래 내역 횟수는 0 이상이어야 합니다.")
-        Integer loanTransactionCount,
+        Integer transactionCountMin,
+        Integer transactionCountMax,
 
         @Min(value = 0, message = "페이지는 0 이상이어야 합니다.")
         Integer page,


### PR DESCRIPTION
## 🔥 Related Issues

- close #67

## 💜 작업 내용
<img width="857" alt="스크린샷 2025-05-14 16 35 03" src="https://github.com/user-attachments/assets/8147aefd-17e0-4d04-9df4-4f8cc8b8b080" />

- [x] 회원 검색 기능에서 생년월일(birthDate) 및 거래내역 횟수(loanTransactionCount) 단일 값 조건을 범위 조건(birthDateStart ~ birthDateEnd, transactionCountMin ~ transactionCountMax)으로 변경
- [x] MemberSearchRequest DTO에 범위 검색 필드 추가 및 기존 필드 대체
- [x] MemberQueryRepositoryImpl의 searchMembers 메서드에서 동적 쿼리(BooleanBuilder)로 범위 조건 반영
- [x] 기존 hasLoan(대출 여부) 필터링 로직 유지

## ✅ PR Point

### DTO 및 쿼리 구조의 변경 이유
기존에는 생년월일과 거래내역 횟수에 대해 단일 값만 검색이 가능했으나, 요구사항에 따라 범위 검색이 필요해졌습니다. 이를 위해 DTO와 쿼리 모두 범위 조건을 지원하도록 리팩토링하였으며, 추후 확장성도 고려해 BooleanBuilder를 사용하였습니다.
(거래내역 수 필터링 시 member.loanApplication.loanTransactions.size()로 접근하는데, JPA 매핑 구조에 따라 N+1 문제가 발생할 여지가 있으니, 추후 실행 계획 분석을 통해 쿼리 튜닝 작업 여부를 판단할 예정입니다.)