### PR TITLE
fIX: 고객 리스트 조회 쿼리 - 거래 횟수 범위 조건을 기반으로 올바른 결과를 반환하도록 쿼리 로직 개선

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.QMember;
 import com.flexrate.flexrate_back.member.dto.MemberSearchRequest;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import lombok.RequiredArgsConstructor;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -78,12 +79,22 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
 
         // loanTransactionCount(거래 횟수) 조건
         if (request.transactionCountMin() != null) {
-            builder.and(member.loanApplication.isNotNull()
-                    .and(member.loanApplication.loanTransactions.size().goe(request.transactionCountMin())));
+            builder.and(
+                    new CaseBuilder()
+                            .when(member.loanApplication.isNull())
+                            .then(0)
+                            .otherwise(member.loanApplication.loanTransactions.size())
+                            .goe(request.transactionCountMin())
+            );
         }
         if (request.transactionCountMax() != null) {
-            builder.and(member.loanApplication.isNotNull()
-                    .and(member.loanApplication.loanTransactions.size().loe(request.transactionCountMax())));
+            builder.and(
+                    new CaseBuilder()
+                            .when(member.loanApplication.isNull())
+                            .then(0)
+                            .otherwise(member.loanApplication.loanTransactions.size())
+                            .loe(request.transactionCountMax())
+            );
         }
 
         List<Member> members = queryFactory.selectFrom(member)


### PR DESCRIPTION
## 🔥 Related Issues

- close #69 

## 💜 작업 내용

- [x] 관련 통합 테스트 및 페이징 totalElements 정상 동작 확인
- [x] 회원 검색 시 거래내역 횟수(transactionCountMin, transactionCountMax) 범위 조건에서 loanApplication이 없는 회원(거래내역 0건)도 정상적으로 포함되도록 QueryDSL 조건문 수정
- [x] 기존 member.loanApplication.isNotNull() 조건을 제거하고, CaseBuilder를 활용해 loanApplication이 null이면 거래내역을 0으로 간주하도록 쿼리 변경

## ✅ PR Point

기존에는 거래내역 횟수 조건 검색 시 대출 신청(loanApplication)이 없는 회원(거래내역 0건)이 결과에서 누락되는 문제가 있었습니다. 이는 member.loanApplication.isNotNull() 조건 때문이었고, 실제로 거래내역 0건 회원도 조건에 부합해야 하므로 쿼리 로직을 수정했습니다.

## 😡 Trouble Shooting

거래내역 횟수 조건에서 loanApplication이 없는 회원이 결과에서 누락되어 totalElements 값이 비정상적으로 감소하는 문제가 있었습니다.

이 문제를 해결하고자 QueryDSL의 CaseBuilder를 활용해 loanApplication이 null이면 거래내역 수를 0으로 처리, 모든 회원이 조건에 맞게 필터링되도록 쿼리를 수정하였습니다.

```java
builder.and(
    new CaseBuilder()
        .when(member.loanApplication.isNull())
        .then(0)
        .otherwise(member.loanApplication.loanTransactions.size())
        .loe(request.transactionCountMax())
);
```

## ☀ 스크린샷 / GIF / 화면 녹화

### 개선 전 - 실제로는 더 많은 데이터가 들어있지만, 제대로 반환되지 않고 5건의 데이터만 반환됨

<img width="893" alt="스크린샷 2025-05-14 20 30 50" src="https://github.com/user-attachments/assets/d3acfa29-ac06-4724-836f-21caec1c1a0d" />

### 개선 후 - 정상적으로 거래 횟수 0의 데이터들이 모두 반환됨

<img width="856" alt="스크린샷 2025-05-14 20 31 35" src="https://github.com/user-attachments/assets/06e8c950-f185-46ba-990d-fd73ace14327" />

