### PR TITLE
fix: selectProduct API 수정 및 관련 파일 추가

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanProductService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanProductService.java
@@ -2,17 +2,22 @@ package com.flexrate.flexrate_back.loan.application;
 
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.loan.application.repository.InterestRepository;
 import com.flexrate.flexrate_back.loan.application.repository.LoanApplicationRepository;
 import com.flexrate.flexrate_back.loan.application.repository.LoanProductRepository;
+import com.flexrate.flexrate_back.loan.application.repository.LoanTransactionRepository;
 import com.flexrate.flexrate_back.loan.domain.LoanApplication;
 import com.flexrate.flexrate_back.loan.domain.LoanProduct;
 import com.flexrate.flexrate_back.loan.dto.LoanProductSummaryDto;
 import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
 import com.flexrate.flexrate_back.loan.enums.LoanType;
 import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 /**
@@ -26,6 +31,9 @@ import java.util.Optional;
 public class LoanProductService {
     private final LoanProductRepository loanProductRepository;
     private final LoanApplicationRepository loanApplicationRepository;
+    private final MemberRepository memberRepository;
+    private final InterestRepository interestRepository;
+    private final LoanTransactionRepository loanTransactionRepository;
 
 
     /**
@@ -58,12 +66,23 @@ public class LoanProductService {
      * @param member 선택한 사용자
      * @throws FlexrateException LOAN_APPLICATION_ALREADY_EXISTS 또는 LOAN_PRODUCT_NOT_FOUND 예외 발생 가능
      */
+    @Transactional
     public void selectProduct(Long productId, Member member) {
-        Optional<LoanApplication> existing = loanApplicationRepository.findByMember(member);
+        Member persistentMember = memberRepository.findById(member.getMemberId())
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+        Optional<LoanApplication> existing = loanApplicationRepository.findByMember(persistentMember);
         if (existing.isPresent()) {
             LoanApplication app = existing.get();
-            if (LoanApplicationStatus.PRE_APPLIED == app.getStatus()) {
+            if (app.getStatus() == LoanApplicationStatus.PRE_APPLIED) {
+                if (app.getInterests() != null) interestRepository.deleteAll(app.getInterests());
+                if (app.getLoanTransactions() != null) loanTransactionRepository.deleteAll(app.getLoanTransactions());
+
+                loanApplicationRepository.flush();
                 loanApplicationRepository.delete(app);
+
+                // member 연관관계 제거
+                app.unlinkMember();
+
                 loanApplicationRepository.flush();
             } else {
                 throw new FlexrateException(ErrorCode.LOAN_APPLICATION_ALREADY_EXISTS);
@@ -74,13 +93,14 @@ public class LoanProductService {
                 .orElseThrow(() -> new FlexrateException(ErrorCode.LOAN_PRODUCT_NOT_FOUND));
 
         LoanApplication application = LoanApplication.builder()
-                .member(member)
+                .member(persistentMember)
                 .product(product)
                 .status(LoanApplicationStatus.PRE_APPLIED)
                 .loanType(LoanType.NEW)
+                .loanTransactions(new ArrayList<>())
+                .interests(new ArrayList<>())
                 .build();
 
         loanApplicationRepository.save(application);
     }
-
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanProductService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanProductService.java
@@ -78,10 +78,11 @@ public class LoanProductService {
                 if (app.getLoanTransactions() != null) loanTransactionRepository.deleteAll(app.getLoanTransactions());
 
                 loanApplicationRepository.flush();
-                loanApplicationRepository.delete(app);
 
                 // member 연관관계 제거
                 app.unlinkMember();
+
+                loanApplicationRepository.delete(app);
 
                 loanApplicationRepository.flush();
             } else {

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanTransactionRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanTransactionRepository.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanTransactionRepository extends JpaRepository<LoanTransaction, Long> {
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -126,13 +126,7 @@ public class LoanApplication {
      */
     public void unlinkMember() {
         if (this.member != null) {
-            try {
-                Field field = Member.class.getDeclaredField("loanApplication");
-                field.setAccessible(true);
-                field.set(this.member, null);
-            } catch (Exception e) {
-                throw new RuntimeException("Member에서 LoanApplication 연관 끊기 실패", e);
-            }
+            this.member.removeLoanApplication(this);
             this.member = null;
         }
     }

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/Member.java
@@ -108,4 +108,10 @@ public class Member {
     public void updateConsumeGoal(ConsumeGoal consumeGoal) {this.consumeGoal = consumeGoal;}
 
     public int getSexCode() {return this.sex == Sex.MALE ? 1 : 2;}
+
+    public void removeLoanApplication(LoanApplication loanApplication) {
+        if (this.loanApplication != null && this.loanApplication.equals(loanApplication)) {
+            this.loanApplication = null;
+        }
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #77 

## 💜 작업 내용

- [x] LoanApplication에 특정 상황에서의 member와 연관관계 제거를 위한 메서드 추가
- [x] LoanApplication의 List<LoanTransaction> loanTransactions을 new ArrayList<>();로 초기화 및 cascade = CascadeType.ALL, orphanRemoval = true 추가
- [x] LoanApplication의 private List<Interest> interests에 loanTransactions와 동일한 코드 추가
- [x] LoanProductService에서 단순 조회를 위한 LoanTransactionRepository 추가
- [x] LoanProductService의 selectProduct 로직 수정
- [x] copilot 리뷰 반영 - unlinkMember()와 delete(app) 순서 변경, unlinkMember()를 헬퍼 메서드로 변경(loanApplication과 Member에 각각 코드 추가) 

## ✅ PR Point

- 프론트와의 연동 시 selectProduct는 사용자가 특정 대출 상품을 선택했을 때 LoanApplication을 미리 생성하고, 기존 대출 신청이 존재할 경우에는 해당 신청의 status가 PRE_APPLIED일 때 삭제 후 생성해주어야 합니다. 기존 코드에서는 삭제가 불가하여 해당 문제 해결을 위해 코드를 수정하였습니다.

## 😡 Trouble Shooting

- 기존 코드에서는 삭제 시도 시 서버 내부 오류가 발생하면서 삭제가 제대로 이루어지지 않는 것을 확인했습니다.


- TransientObjectException 오류가 발생. LoanApplication 객체를 저장하려고 했지만, Hibernate 내부 flush 과정에서 아직 저장되지 않은 LoanApplication을 참조하는 다른 객체가 존재한다고 판단해 예외 발생한 것으로 loanApplicationRepository.delete(app); 후 flush()를 호출했을 때 문제가 생긴 걸 확인했습니다. 
- 연관된 자식 엔티티가 존재하는 상태에서 부모 삭제 시 문제가 발생하는데, LoanApplication에는 loanTransactions와 interests가 존재. 이 둘이 cascade 설정 없이 그대로 존재하고, 둘의 리스트가 초기화 되지 않아 LoanApplication 객체가 생성될 때 loanTransactions와 interests 리스트가 null인 것, 부모가 저장되기 전에 자식이 생성되며 참조하는 문제들이 있어서 삭제 시 TransientObjectException가 발생하였으므로 작업 내용에 기재한 것과 같이 해당 코드들을 수정하였습니다.
```
@OneToMany(mappedBy = "loanApplication", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<Interest> interests = new ArrayList<>();

@OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<LoanTransaction> loanTransactions = new ArrayList<>();
```

- 그러나 이후에도 TransientObjectException이 발생. 코드를 다시 살펴본 결과 LoanApplication이 Member와 양방향 연관 관계를 가지는 것 때문에 @OneToOne(mappedBy = "member")로 설정된 상태에서 member 필드를 null 처리하지 않으면 foreign key constraint로 인한 오류도 추가 발생하는 것을 확인했습니다. 따라서 LoanApplication에 unlinkMember() 메서드를 추가하여 member와의 연관관계를 제거했습니다.
```
    /**
     * Member와 연관관계 제거
     *
     */
    public void unlinkMember() {
        if (this.member != null) {
            try {
                Field field = Member.class.getDeclaredField("loanApplication");
                field.setAccessible(true);
                field.set(this.member, null);
            } catch (Exception e) {
                throw new RuntimeException("Member에서 LoanApplication 연관 끊기 실패", e);
            }
            this.member = null;
        }
    }
```

- 로직 수정은 다음과 같습니다. 연관 관계 직접 제거 처리를 위해 loanTransactions, interests를 먼저 명시적으로 deleteAll() 처리한 것과 deleteAll() 후 영속성 컨텍스트 반영을 위한 flush() 호출, 이후 LoanApplication 삭제하고 Member와의 연관 관계 제거를 위해 unlinkMember() 사용 후 다시 영속성 컨텍스트 반영을 위한 flush() 호출입니다.
```
                if (app.getInterests() != null) interestRepository.deleteAll(app.getInterests());
                if (app.getLoanTransactions() != null) loanTransactionRepository.deleteAll(app.getLoanTransactions());

                loanApplicationRepository.flush();
                loanApplicationRepository.delete(app);

                // member 연관관계 제거
                app.unlinkMember();

                loanApplicationRepository.flush();
```

- 또한 상단의
```
Member persistentMember = memberRepository.findById(member.getMemberId())
                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
```
코드의 경우 member와 관련하여 컨트롤러 혹은 서비스 호출 시 전달된 member 객체는 비영속 상태일 가능성이 있어 오류가 발생할 수 있으므로 영속 엔티티로 다시 조회해주는 로직을 추가했습니다.


- LoanTransactionRepository는 LoanProductService의 selectProduct 내부 로직에서 loanTransaction이 null인지 아닌지 판단할 때의 단순 조회를 위해서 추가하였으며 interests의 경우에도 동일한 조회를 위해 InterestRepository를 불러왔습니다.


## ☀ 스크린샷 / GIF / 화면 녹화

