### PR TITLE
feat: 회원 신용 정보 산정 이력 테이블 및 신용점수 산정 이력 테이블 추가 & 변경에 따른 flyway 버전관리

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanService.java
@@ -5,8 +5,10 @@ import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.financialdata.domain.UserFinancialData;
 import com.flexrate.flexrate_back.financialdata.enums.UserFinancialDataType;
 import com.flexrate.flexrate_back.loan.application.repository.LoanApplicationRepository;
+import com.flexrate.flexrate_back.loan.application.repository.LoanReviewHistoryRepository;
 import com.flexrate.flexrate_back.loan.domain.LoanApplication;
 import com.flexrate.flexrate_back.loan.domain.LoanProduct;
+import com.flexrate.flexrate_back.loan.domain.LoanReviewHistory;
 import com.flexrate.flexrate_back.loan.dto.LoanApplicationRequest;
 import com.flexrate.flexrate_back.loan.dto.LoanApplicationResultResponse;
 import com.flexrate.flexrate_back.loan.dto.LoanReviewApplicationRequest;
@@ -48,6 +50,7 @@ public class LoanService {
     // 심사 서버 URL (추후 변경 예정)
     private static final String SCREENING_SERVER_URL = "http://external-server/api";
     private final LoanApplicationRepository loanApplicationRepository;
+    private final LoanReviewHistoryRepository loanReviewHistoryRepository;
 
     /**
      * 대출 신청 사전 정보를 외부 심사 서버로 전달 후, 심사 결과 저장
@@ -108,7 +111,18 @@ public class LoanService {
                 .terms(product.getTerms())
                 .build();
 
-        loanApplication.applyReviewResult(externalResponse);
+        // 대출 신청 사전 정보 저장
+        LoanReviewHistory loanReviewHistory = LoanReviewHistory.builder()
+                .employmentType(request.employmentType())
+                .annualIncome(request.annualIncome())
+                .residenceType(request.residenceType())
+                .isBankrupt(request.isBankrupt())
+                .loanPurpose(request.loanPurpose())
+                .application(loanApplication)
+                .build();
+
+        loanReviewHistoryRepository.save(loanReviewHistory);
+        loanApplication.applyReviewResult(externalResponse, loanReviewHistory);
     }
 
     /**

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanReviewHistoryRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/repository/LoanReviewHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.loan.application.repository;
+
+import com.flexrate.flexrate_back.loan.domain.LoanReviewHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanReviewHistoryRepository extends JpaRepository<LoanReviewHistory, Long> {
+}

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -59,6 +59,10 @@ public class LoanApplication {
     @OneToMany(mappedBy = "loanApplication")
     private List<Interest> interests;
 
+    @OneToOne
+    @JoinColumn(name = "review_id")
+    private LoanReviewHistory reviewHistory; // 대출 심사 이력
+
 
     // 대출 상태 변경
     public void patchStatus(LoanApplicationStatus status) {
@@ -72,14 +76,15 @@ public class LoanApplication {
 
     /**
      * 대출 상태 전환 유효성 체크
-     * 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED
+     * 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> PRE_APPLIED
      * @param currentStatus 현재 대출 상태
      * @param newStatus 변경할 대출 상태
      * @return true: 유효한 상태 전환, false: 유효하지 않은 상태 전환
      */
     public boolean isTransitionValid(LoanApplicationStatus currentStatus, LoanApplicationStatus newStatus) {
         return (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
-                (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.COMPLETED);
+                (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.COMPLETED) ||
+                (currentStatus == LoanApplicationStatus.COMPLETED && newStatus == LoanApplicationStatus.PRE_APPLIED);
     }
     /**
      * 대출 심사 결과 반영
@@ -87,12 +92,13 @@ public class LoanApplication {
      * @param response 대출심사결과
      * @return true: 유효한 상태 전환인 경우, false: 유효하지 않은 경우
      */
-    public void applyReviewResult(LoanReviewApplicationResponse response) {
+    public void applyReviewResult(LoanReviewApplicationResponse response, LoanReviewHistory loanReviewHistory) {
         this.totalAmount = response.loanLimit();
         this.remainAmount = response.loanLimit();
         this.rate = response.initialRate();
         this.creditScore = response.creditScore();
         this.appliedAt = LocalDateTime.now();
+        this.reviewHistory = loanReviewHistory;
     }
 
     /**

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
@@ -22,9 +22,14 @@ public class LoanReviewHistory {
     @JoinColumn(name = "application_id", nullable = false)
     private LoanApplication application;                  // 대출 신청서
 
+    @Column(name = "employment_type", length = 30)
     private String employmentType;                        // 고용형태
     private Integer annualIncome;                         // 연소득
+
+    @Column(name = "residence_type", length = 30)
     private String residenceType;                         // 주거형태
     private Boolean isBankrupt;                           // 개인회생 여부
+
+    @Column(name = "loan_purpose", length = 50)
     private String loanPurpose;                           // 대출목적
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
@@ -1,0 +1,30 @@
+package com.flexrate.flexrate_back.loan.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "LoanReviewHistory")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoanReviewHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reviewId;
+
+    @OneToOne
+    @JoinColumn(name = "application_id", nullable = false)
+    private LoanApplication application;                  // 대출 신청서
+
+    private String employmentType;                        // 고용형태
+    private Integer annualIncome;                         // 연소득
+    private String residenceType;                         // 주거형태
+    private Boolean isBankrupt;                           // 개인회생 여부
+    private String loanPurpose;                           // 대출목적
+}

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/MemberCreditSummary.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/MemberCreditSummary.java
@@ -5,9 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @Table(name = "MemberCreditSummary")
 @Getter
@@ -24,9 +28,9 @@ public class MemberCreditSummary {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(name = "calculated_at", nullable = false, updatable = false)
-    @Builder.Default
-    private LocalDateTime calculatedAt = LocalDateTime.now();
+    @CreatedDate
+    @Column(name = "calculated_at", nullable = false)
+    private LocalDateTime calculatedAt;
 
     @Column(name = "total_loan_count", nullable = false)
     @Builder.Default

--- a/src/main/java/com/flexrate/flexrate_back/member/domain/MemberCreditSummary.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/domain/MemberCreditSummary.java
@@ -1,0 +1,83 @@
+package com.flexrate.flexrate_back.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "MemberCreditSummary")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberCreditSummary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long summaryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "calculated_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime calculatedAt = LocalDateTime.now();
+
+    @Column(name = "total_loan_count", nullable = false)
+    @Builder.Default
+    private Integer totalLoanCount = 0;
+
+    @Column(name = "active_loan_count", nullable = false)
+    @Builder.Default
+    private Integer activeLoanCount = 0;
+
+    @Column(name = "total_loan_balance", nullable = false)
+    @Builder.Default
+    private Integer totalLoanBalance = 0;
+
+    @Column(name = "total_loan_overdue_30d", nullable = false)
+    @Builder.Default
+    private Integer totalLoanOverdue30d = 0;
+
+    @Column(name = "total_loan_overdue_90d", nullable = false)
+    @Builder.Default
+    private Integer totalLoanOverdue90d = 0;
+
+    @Column(name = "has_current_overdue", nullable = false)
+    @Builder.Default
+    private Boolean hasCurrentOverdue = false;
+
+    @Column(name = "last_overdue_date")
+    @Temporal(TemporalType.DATE)
+    private LocalDate lastOverdueDate;
+
+    @Column(name = "comm_overdue_count", nullable = false)
+    @Builder.Default
+    private Integer commOverdueCount = 0;
+
+    @Column(name = "comm_overdue_max_days", nullable = false)
+    @Builder.Default
+    private Integer commOverdueMaxDays = 0;
+
+    @Column(name = "utility_overdue_count", nullable = false)
+    @Builder.Default
+    private Integer utilityOverdueCount = 0;
+
+    @Column(name = "utility_overdue_max_days", nullable = false)
+    @Builder.Default
+    private Integer utilityOverdueMaxDays = 0;
+
+    @Column(name = "credit_score", nullable = false)
+    private Integer creditScore;
+
+    @Column(name = "interest_rate", nullable = false)
+    private Float interestRate;
+
+    @Column(name = "remark", length = 255)
+    private String remark;
+}

--- a/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitCategory.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitCategory.java
@@ -20,7 +20,7 @@ public class ConsumptionHabitCategory {
     private Long categoryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "report_id", nullable = false)
     private ConsumptionHabitReport report;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -25,7 +25,7 @@ create table member_credit_summary
 (
     id                         bigint auto_increment primary key,
     member_id                  bigint       not null,
-    calculated_at              datetime(6)  not null default current_timestamp, -- 평가 시점
+    calculated_at              datetime(6)  not null,                          -- 평가 시점
     total_loan_count           int          not null default 0,                -- 보유 대출 건수
     active_loan_count          int          not null default 0,                -- 현재 상환 중인 대출 건수
     total_loan_balance         int          not null default 0,                -- 전체 대출 잔액

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -37,8 +37,8 @@ create table member_credit_summary
     comm_overdue_max_days      int          not null default 0,                -- 통신비 최장 연체일수
     utility_overdue_count      int          not null default 0,                -- 공과금 연체 건수
     utility_overdue_max_days   int          not null default 0,                -- 공과금 최장 연체일수
-    credit_score               int          null,                              -- 신용점수(산정 결과)
-    interest_rate              float        null,                              -- 금리(산정 결과)
+    credit_score               int          not null,                          -- 신용점수(산정 결과)
+    interest_rate              float        not null,                          -- 금리(산정 결과)
     remark                     varchar(255) null,                              -- 비고
     constraint FK_member_credit_summary_member foreign key (member_id) references member (member_id)
 );

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -71,9 +71,9 @@ create table loan_application
     start_date     datetime(6)                                                          null,
     loan_type      enum ('EXTENSION', 'NEW', 'REJOIN')                                  not null,
     status         enum ('COMPLETED', 'EXECUTED', 'PENDING', 'PRE_APPLIED', 'REJECTED') not null,
-    constraint UKnu7i3b6jnfvmb18oufct4mbv0 unique (member_id),
-    constraint FKeewfg5rtu0ux0gv0n357t6g1v foreign key (member_id) references member (member_id),
-    constraint FKeyryxaov7qn04ctajae14l9sf foreign key (product_id) references loan_product (product_id)
+    constraint UK_loan_application_member unique (member_id),
+    constraint FK_loan_application_member foreign key (member_id) references member (member_id),
+    constraint FK_loan_application_product foreign key (product_id) references loan_product (product_id)
 );
 
 -- FIDO_CREDENTIAL (패스키)
@@ -86,8 +86,8 @@ create table fido_credential
     member_id      bigint        not null,
     device_info    varchar(20)   not null,
     public_key     varchar(1000) not null,
-    constraint UKmsct6biuq32sdb2e8icuu4t68 unique (member_id),
-    constraint FKs3bknrmcmske2xkvd96ga2myj foreign key (member_id) references member (member_id)
+    constraint UK_fido_credential_member unique (member_id),
+    constraint FK_fido_credential_member foreign key (member_id) references member (member_id)
 );
 
 -- LOAN_TRANSACTION (대출 거래)
@@ -100,8 +100,8 @@ create table loan_transaction
     transaction_id bigint auto_increment primary key,
     status         enum ('CANCELLED', 'FAILED', 'NORMAL')   not null,
     type           enum ('DELAY', 'EXECUTION', 'REPAYMENT') not null,
-    constraint FK8gityivfar00t9fc7lgyqx0s foreign key (member_id) references member (member_id),
-    constraint FKntk7t4npuvm0ryaq2wl32514w foreign key (application_id) references loan_application (application_id)
+    constraint FK_loan_transaction_member foreign key (member_id) references member (member_id),
+    constraint FK_loan_transaction_application foreign key (application_id) references loan_application (application_id)
 );
 
 -- MFA_LOG (다중 인증 로그)
@@ -113,7 +113,7 @@ create table mfa_log
     device_info      varchar(20)                            null,
     mfa_type         enum ('EMAIL', 'FIDO2', 'PASS', 'SMS') not null,
     result           enum ('FAILURE', 'SUCCESS')            not null,
-    constraint FKkytl8f2c6q4ry0eihdyvwn3k1 foreign key (transaction_id) references loan_transaction (transaction_id)
+    constraint FK_mfa_log_transaction foreign key (transaction_id) references loan_transaction (transaction_id)
 );
 
 -- INTEREST (변동 금리)
@@ -123,7 +123,7 @@ create table interest
     application_id bigint      not null,
     interest_date  datetime(6) not null,
     interest_id    bigint auto_increment primary key,
-    constraint FK71miynswoeucff7manm0xth9g foreign key (application_id) references loan_application (application_id)
+    constraint FK_interest_loan_application foreign key (application_id) references loan_application (application_id)
 );
 
 -- NOTIFICATION (알림)
@@ -135,7 +135,7 @@ create table notification
     sent_at         datetime(6)                               not null,
     content         varchar(50)                               not null,
     type            enum ('LOAN_APPROVAL', 'MATURITY_NOTICE', 'INTEREST_RATE_CHANGE') not null,
-    constraint FK1xep8o2ge7if6diclyyx53v4q foreign key (member_id) references member (member_id)
+    constraint FK_notification_member foreign key (member_id) references member (member_id)
 );
 
 -- REFRESH_TOKEN (리프레시 토큰)
@@ -144,7 +144,7 @@ create table refresh_token
     id            bigint auto_increment primary key,
     member_id     bigint       not null,
     refresh_token varchar(255) not null,
-    constraint UKdnbbikqdsc2r2cee1afysqfk9 unique (member_id)
+    constraint UK_refresh_token_member unique (member_id)
 );
 
 -- USER_FINANCIAL_DATA (유저 재무 데이터)
@@ -156,7 +156,7 @@ create table user_financial_data
     user_id      bigint                                                                                         not null,
     category     enum ('COMMUNICATION', 'EDUCATION', 'ETC', 'FOOD', 'HEALTH', 'LEISURE', 'LIVING', 'TRANSPORT') null,
     data_type    enum ('EXPENSE', 'INCOME')                                                     not null,
-    constraint FKqk7w04q7gt20twv8xi8y17865 foreign key (user_id) references member (member_id)
+    constraint FK_user_financial_data_member foreign key (user_id) references member (member_id)
 );
 
 -- CONSUMPTION_HABIT_REPORT (소비 습관 리포트)
@@ -167,8 +167,8 @@ create table consumption_habit_report
     member_id    bigint       not null,
     report_id    bigint auto_increment primary key,
     summary      varchar(500) null,
-    constraint UK1n794ss5uofb3j16hsnj3l21e unique (member_id, report_month),
-    constraint FKmq81atoh4ght2iogu5ouictrn foreign key (member_id) references member (member_id)
+    constraint UK_consumption_habit_report_member_report_month unique (member_id, report_month),
+    constraint FK_consumption_habbit_report_member foreign key (member_id) references member (member_id)
 );
 
 -- CONSUMPTION_HABIT_CATEGORY (소비 습관 카테고리)
@@ -194,7 +194,7 @@ create table audit_log
     device_info varchar(100) null,
     action      varchar(255) not null,
     detail      varchar(255) null,
-    constraint FK5bcyk09s5o5ss2oag9kbcrvha foreign key (member_id) references member (member_id),
+    constraint FK_audit_log_member foreign key (member_id) references member (member_id),
     check (`auth_method` between 0 and 1),
     check (`event_type` between 0 and 2)
 );
@@ -210,9 +210,9 @@ create table authentication
     ip_address       varchar(20)          null,
     device_info      varchar(100)         null,
     auth_method      enum ('FIDO', 'MFA') null,
-    constraint UK3hebrkl6ex5u6xv8wrj0m13mf unique (credential_id),
-    constraint UKd3jsewxyq9sxygyaau5q46jcv unique (mfa_log_id),
-    constraint FK2q7688loi42jwjgvh8q5s1te3 foreign key (credential_id) references fido_credential (credential_id),
-    constraint FK8u5ywo54pknmfyi542m7ou80 foreign key (mfa_log_id) references mfa_log (mfa_log_id),
-    constraint FKt8w1awoivi0ilqtrwqrjwq2s2 foreign key (member_id) references member (member_id)
+    constraint UK_authentication_credential unique (credential_id),
+    constraint UK_authentication_mfa_log unique (mfa_log_id),
+    constraint FK_authentication_fido_credential foreign key (credential_id) references fido_credential (credential_id),
+    constraint FK_authentication_mfa_log foreign key (mfa_log_id) references mfa_log (mfa_log_id),
+    constraint FK_authentication_member foreign key (member_id) references member (member_id)
 );

--- a/src/main/resources/db/migration/V2__add_loan_review_history.sql
+++ b/src/main/resources/db/migration/V2__add_loan_review_history.sql
@@ -1,0 +1,12 @@
+-- LOAN_REVIEW_HISTORY (대출 심사 이력)
+create table loan_review_history
+(
+    review_id       bigint auto_increment primary key,
+    application_id  bigint       not null,
+    employment_type varchar(30)  null,
+    annual_income   int          null,
+    residence_type  varchar(30)  null,
+    is_bankrupt     bit          null,
+    loan_purpose    varchar(50)  null,
+    constraint FK_loan_review_history_application foreign key (application_id) references loan_application (application_id)
+);

--- a/src/main/resources/db/migration/V2__add_loan_review_history.sql
+++ b/src/main/resources/db/migration/V2__add_loan_review_history.sql
@@ -10,3 +10,8 @@ create table loan_review_history
     loan_purpose    varchar(50)  null,
     constraint FK_loan_review_history_application foreign key (application_id) references loan_application (application_id)
 );
+
+-- LOAN_APPLICATION (대출 신청) 테이블에 대출 심사 이력 연관관계 추가
+alter table loan_application
+    add review_id bigint null,
+    add constraint FK_loan_application_review foreign key (review_id) references loan_review_history (review_id);

--- a/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
+++ b/src/main/resources/db/migration/V999__init_dev_dummy_data.sql
@@ -1,51 +1,51 @@
 -- MEMBER (member 33, admin 1)
-insert into member(age, birth_date, created_at, last_login_at, password_last_changed_at, updated_at, name, phone, email, password_hash, consume_goal, consumption_type, last_login_method, role, sex, status)
+insert into member(member_id, age, birth_date, created_at, last_login_at, password_last_changed_at, updated_at, name, phone, email, password_hash, consume_goal, consumption_type, last_login_method, role, sex, status)
 values
     -- ADMIN
-    (null, '1988-03-03', now(6), now(6), now(6), now(6), '관리자', '010-0000-0000', 'admin@email.com', '$2a$12$BBE6HrevyW5y6tMmgoLmyes2D.jIHdjeFK99YQ3ozo8gyZ9LLbozy', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSWORD', 'ADMIN', 'MALE', 'SUSPENDED'),
+    (1, null, '1988-03-03', now(6), now(6), now(6), now(6), '관리자', '010-0000-0000', 'admin@email.com', '$2a$12$BBE6HrevyW5y6tMmgoLmyes2D.jIHdjeFK99YQ3ozo8gyZ9LLbozy', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSWORD', 'ADMIN', 'MALE', 'SUSPENDED'),
 
     -- CONSERVATIVE (4)
-    (null, '1992-02-02', now(6), now(6), now(6), now(6), '김영희', '010-2222-2222', 'member2@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1990-01-10', now(6), now(6), now(6), now(6), '최성민', '010-5555-5555', 'member5@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'LIMIT_DAILY_MEAL', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1987-07-17', now(6), now(6), now(6), now(6), '박서진', '010-6666-6666', 'member6@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SAVE_70_PERCENT', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1985-12-05', now(6), now(6), now(6), now(6), '이진우', '010-7777-7777', 'member7@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'INCOME_OVER_EXPENSE', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (2, null, '1992-02-02', now(6), now(6), now(6), now(6), '김영희', '010-2222-2222', 'member2@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (3, null, '1990-01-10', now(6), now(6), now(6), now(6), '최성민', '010-5555-5555', 'member5@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'LIMIT_DAILY_MEAL', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (4, null, '1987-07-17', now(6), now(6), now(6), now(6), '박서진', '010-6666-6666', 'member6@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SAVE_70_PERCENT', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (5, null, '1985-12-05', now(6), now(6), now(6), now(6), '이진우', '010-7777-7777', 'member7@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'INCOME_OVER_EXPENSE', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
 
     -- PRACTICAL (4)
-    (null, '1989-08-08', now(6), now(6), now(6), now(6), '정하늘', '010-8888-8888', 'member8@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'COMPARE_BEFORE_BUYING', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1991-09-09', now(6), now(6), now(6), now(6), '윤지훈', '010-9999-9999', 'member9@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1993-03-03', now(6), now(6), now(6), now(6), '한유진', '010-1010-1010', 'member10@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'CLOTHING_UNDER_100K', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1986-06-06', now(6), now(6), now(6), now(6), '김태현', '010-1212-1212', 'member11@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (6, null, '1989-08-08', now(6), now(6), now(6), now(6), '정하늘', '010-8888-8888', 'member8@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'COMPARE_BEFORE_BUYING', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (7, null, '1991-09-09', now(6), now(6), now(6), now(6), '윤지훈', '010-9999-9999', 'member9@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
+    (8, null, '1993-03-03', now(6), now(6), now(6), now(6), '한유진', '010-1010-1010', 'member10@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'CLOTHING_UNDER_100K', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (9, null, '1986-06-06', now(6), now(6), now(6), now(6), '김태현', '010-1212-1212', 'member11@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
 
     -- BALANCED (4)
-    (null, '1995-01-01', now(6), now(6), now(6), now(6), '홍길동', '010-1111-1111', 'member1@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONE_CATEGORY_SPEND', 'BALANCED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1998-05-05', now(6), now(6), now(6), now(6), '이수진', '010-4444-4444', 'member4@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1994-04-14', now(6), now(6), now(6), now(6), '서지호', '010-1313-1313', 'member12@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_USELESS_ELECTRONICS', 'BALANCED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1996-06-16', now(6), now(6), now(6), now(6), '조민아', '010-1414-1414', 'member13@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'OVER_10_PERCENT', 'BALANCED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (10, null, '1995-01-01', now(6), now(6), now(6), now(6), '홍길동', '010-1111-1111', 'member1@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONE_CATEGORY_SPEND', 'BALANCED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (11, null, '1998-05-05', now(6), now(6), now(6), now(6), '이수진', '010-4444-4444', 'member4@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (12, null, '1994-04-14', now(6), now(6), now(6), now(6), '서지호', '010-1313-1313', 'member12@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_USELESS_ELECTRONICS', 'BALANCED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (13, null, '1996-06-16', now(6), now(6), now(6), now(6), '조민아', '010-1414-1414', 'member13@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'OVER_10_PERCENT', 'BALANCED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
 
     -- CONSUMPTION_ORIENTED (4)
-    (null, '2000-04-04', now(6), now(6), now(6), now(6), '박민정', '010-3333-3333', 'member3@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'WITHDRAWN'),
-    (null, '1997-07-07', now(6), now(6), now(6), now(6), '신동욱', '010-1515-1515', 'member14@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_OVER_50K_PER_DAY', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1999-09-09', now(6), now(6), now(6), now(6), '문지수', '010-1616-1616', 'member15@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SUBSCRIPTION_UNDER_50K', 'CONSUMPTION_ORIENTED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1993-12-12', now(6), now(6), now(6), now(6), '임채원', '010-1717-1717', 'member16@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'MEAL_UNDER_20K', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (14, null, '2000-04-04', now(6), now(6), now(6), now(6), '박민정', '010-3333-3333', 'member3@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'WITHDRAWN'),
+    (15, null, '1997-07-07', now(6), now(6), now(6), now(6), '신동욱', '010-1515-1515', 'member14@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_OVER_50K_PER_DAY', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (16, null, '1999-09-09', now(6), now(6), now(6), now(6), '문지수', '010-1616-1616', 'member15@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SUBSCRIPTION_UNDER_50K', 'CONSUMPTION_ORIENTED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (17, null, '1993-12-12', now(6), now(6), now(6), now(6), '임채원', '010-1717-1717', 'member16@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'MEAL_UNDER_20K', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
 
     -- 나머지 멤버(랜덤 배치, 총 33명 맞추기 위해 17명 추가)
-    (null, '1990-02-10', now(6), now(6), now(6), now(6), '김도현', '010-1818-1818', 'member17@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1991-03-15', now(6), now(6), now(6), now(6), '이유림', '010-1919-1919', 'member18@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'LIMIT_DAILY_MEAL', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1992-04-20', now(6), now(6), now(6), now(6), '박은서', '010-2020-2020', 'member19@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SAVE_70_PERCENT', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1993-05-25', now(6), now(6), now(6), now(6), '최승훈', '010-2121-2121', 'member20@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'INCOME_OVER_EXPENSE', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1994-06-30', now(6), now(6), now(6), now(6), '정다은', '010-2222-2323', 'member21@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'COMPARE_BEFORE_BUYING', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1995-07-05', now(6), now(6), now(6), now(6), '한수빈', '010-2424-2424', 'member22@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1996-08-10', now(6), now(6), now(6), now(6), '서지훈', '010-2525-2525', 'member23@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'CLOTHING_UNDER_100K', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1997-09-15', now(6), now(6), now(6), now(6), '문예린', '010-2626-2626', 'member24@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '1998-10-20', now(6), now(6), now(6), now(6), '신유진', '010-2727-2727', 'member25@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONE_CATEGORY_SPEND', 'BALANCED', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '1999-11-25', now(6), now(6), now(6), now(6), '오지혁', '010-2828-2828', 'member26@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '2000-12-30', now(6), now(6), now(6), now(6), '이서준', '010-2929-2929', 'member27@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_USELESS_ELECTRONICS', 'BALANCED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '2001-01-04', now(6), now(6), now(6), now(6), '최지아', '010-3030-3030', 'member28@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'OVER_10_PERCENT', 'BALANCED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '2002-02-08', now(6), now(6), now(6), now(6), '임도윤', '010-3131-3131', 'member29@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '2003-03-12', now(6), now(6), now(6), now(6), '강지우', '010-3232-3232', 'member30@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_OVER_50K_PER_DAY', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '2004-04-16', now(6), now(6), now(6), now(6), '서하윤', '010-3333-3333', 'member31@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SUBSCRIPTION_UNDER_50K', 'CONSUMPTION_ORIENTED', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
-    (null, '2005-05-20', now(6), now(6), now(6), now(6), '박시윤', '010-3434-3434', 'member32@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'MEAL_UNDER_20K', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
-    (null, '2006-06-24', now(6), now(6), now(6), now(6), '조하람', '010-3535-3535', 'member33@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE');
+    (18, null, '1990-02-10', now(6), now(6), now(6), now(6), '김도현', '010-1818-1818', 'member17@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (19, null, '1991-03-15', now(6), now(6), now(6), now(6), '이유림', '010-1919-1919', 'member18@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'LIMIT_DAILY_MEAL', 'CONSERVATIVE', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (20, null, '1992-04-20', now(6), now(6), now(6), now(6), '박은서', '010-2020-2020', 'member19@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SAVE_70_PERCENT', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (21, null, '1993-05-25', now(6), now(6), now(6), now(6), '최승훈', '010-2121-2121', 'member20@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'INCOME_OVER_EXPENSE', 'CONSERVATIVE', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (22, null, '1994-06-30', now(6), now(6), now(6), now(6), '정다은', '010-2222-2323', 'member21@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'COMPARE_BEFORE_BUYING', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (23, null, '1995-07-05', now(6), now(6), now(6), now(6), '한수빈', '010-2424-2424', 'member22@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'HAS_HOUSING_SAVING', 'PRACTICAL', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (24, null, '1996-08-10', now(6), now(6), now(6), now(6), '서지훈', '010-2525-2525', 'member23@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'CLOTHING_UNDER_100K', 'PRACTICAL', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (25, null, '1997-09-15', now(6), now(6), now(6), now(6), '문예린', '010-2626-2626', 'member24@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONLY_PUBLIC_TRANSPORT', 'PRACTICAL', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (26, null, '1998-10-20', now(6), now(6), now(6), now(6), '신유진', '010-2727-2727', 'member25@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'ONE_CATEGORY_SPEND', 'BALANCED', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
+    (27, null, '1999-11-25', now(6), now(6), now(6), now(6), '오지혁', '010-2828-2828', 'member26@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SMALL_MONTHLY_SAVE', 'BALANCED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (28, null, '2000-12-30', now(6), now(6), now(6), now(6), '이서준', '010-2929-2929', 'member27@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_USELESS_ELECTRONICS', 'BALANCED', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE'),
+    (29, null, '2001-01-04', now(6), now(6), now(6), now(6), '최지아', '010-3030-3030', 'member28@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'OVER_10_PERCENT', 'BALANCED', 'SOCIAL', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (30, null, '2002-02-08', now(6), now(6), now(6), now(6), '임도윤', '010-3131-3131', 'member29@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_EXPENSIVE_DESSERT', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'MALE', 'ACTIVE'),
+    (31, null, '2003-03-12', now(6), now(6), now(6), now(6), '강지우', '010-3232-3232', 'member30@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_OVER_50K_PER_DAY', 'CONSUMPTION_ORIENTED', 'PASSWORD', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (32, null, '2004-04-16', now(6), now(6), now(6), now(6), '서하윤', '010-3333-3333', 'member31@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'SUBSCRIPTION_UNDER_50K', 'CONSUMPTION_ORIENTED', 'SOCIAL', 'MEMBER', 'MALE', 'ACTIVE'),
+    (33, null, '2005-05-20', now(6), now(6), now(6), now(6), '박시윤', '010-3434-3434', 'member32@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'MEAL_UNDER_20K', 'CONSUMPTION_ORIENTED', 'PASSKEY', 'MEMBER', 'FEMALE', 'ACTIVE'),
+    (34, null, '2006-06-24', now(6), now(6), now(6), now(6), '조하람', '010-3535-3535', 'member33@email.com', '$2a$12$B2ogNikMQCOZ5Ulapyxtn.5Z3i323vYWRlHLspgx/aZgJPrQGmeT2', 'NO_SPENDING_TODAY', 'CONSERVATIVE', 'PASSWORD', 'MEMBER', 'MALE', 'ACTIVE');
 
 
 -- LOAN_PRODUCT (대출 상품)
@@ -88,8 +88,7 @@ values
     (805, 3.7, 0, 500000, 31, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 19 month), date_sub(now(), interval 19 month), date_add(now(), interval 17 month), date_sub(now(), interval 18 month)),
     (690, 8.5, 1500000, 3500000, 32, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 2 month), date_sub(now(), interval 2 month), date_add(now(), interval 34 month), date_sub(now(), interval 1 month)),
     (750, 5.9, 0, 2000000, 33, 1, 'REJOIN', 'PENDING', date_sub(now(), interval 1 month), null, null, null),
-    (820, 3.6, 0, 650000, 34, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 28 month), date_sub(now(), interval 28 month), date_add(now(), interval 8 month), date_sub(now(), interval 27 month)),
-    (740, 6.1, 600000, 1700000, 35, 1, 'NEW', 'EXECUTED', date_sub(now(), interval 13 month), date_sub(now(), interval 13 month), date_add(now(), interval 23 month), date_sub(now(), interval 12 month));
+    (820, 3.6, 0, 650000, 34, 1, 'NEW', 'COMPLETED', date_sub(now(), interval 28 month), date_sub(now(), interval 28 month), date_add(now(), interval 8 month), date_sub(now(), interval 27 month));
 
 -- LOAN_TRANSACTION
 insert into loan_transaction (amount, application_id, member_id, occurred_at, status, type)
@@ -127,9 +126,9 @@ values
     (500000, 20, 23, date_sub(now(), interval 13 month), 'NORMAL', 'REPAYMENT'),
 
     -- application_id: 22, member_id: 25, 집행/상환/연체
-    (1700000, 22, 35, date_sub(now(), interval 12 month), 'NORMAL', 'EXECUTION'),
-    (400000, 22, 35, date_sub(now(), interval 10 month), 'NORMAL', 'REPAYMENT'),
-    (300000, 22, 35, date_sub(now(), interval 2 month), 'FAILED', 'DELAY');
+    (1700000, 22, 34, date_sub(now(), interval 12 month), 'NORMAL', 'EXECUTION'),
+    (400000, 22, 34, date_sub(now(), interval 10 month), 'NORMAL', 'REPAYMENT'),
+    (300000, 22, 34, date_sub(now(), interval 2 month), 'FAILED', 'DELAY');
 
 -- INTEREST
 insert into interest (interest_rate, application_id, interest_date)
@@ -216,21 +215,7 @@ values
 (6.895, 29, date_sub(now(), interval 3 day)),
 (6.890, 29, date_sub(now(), interval 2 day)),
 (6.888, 29, date_sub(now(), interval 1 day)),
-(6.885, 29, now()),
-
--- application_id: 32 (8.5% → 점진적 하락)
-(8.500, 32, date_sub(now(), interval 4 day)),
-(8.495, 32, date_sub(now(), interval 3 day)),
-(8.490, 32, date_sub(now(), interval 2 day)),
-(8.488, 32, date_sub(now(), interval 1 day)),
-(8.485, 32, now()),
-
--- application_id: 35 (6.1% → 소폭 등락, 전체적 하락)
-(6.100, 35, date_sub(now(), interval 4 day)),
-(6.102, 35, date_sub(now(), interval 3 day)), -- 소폭 상승
-(6.099, 35, date_sub(now(), interval 2 day)),
-(6.094, 35, date_sub(now(), interval 1 day)),
-(6.091, 35, now());
+(6.885, 29, now());
 
 -- NOTIFICATION
 insert into notification (is_read, member_id, sent_at, content, type)
@@ -245,11 +230,10 @@ values
 (0, 21, date_sub(now(), interval 9 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 (1, 23, date_sub(now(), interval 6 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 (0, 25, date_sub(now(), interval 17 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
-(0, 35, date_sub(now(), interval 3 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 (1, 27, date_sub(now(), interval 7 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 (0, 29, date_sub(now(), interval 5 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 (0, 32, date_sub(now(), interval 2 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
-(1, 35, date_sub(now(), interval 13 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
+(1, 34, date_sub(now(), interval 13 month), '대출이 승인되었습니다.', 'LOAN_APPROVAL'),
 
 -- 금리 변동 알림
 (0, 2, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
@@ -261,11 +245,9 @@ values
 (0, 21, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
 (0, 23, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
 (1, 25, date_sub(now(), interval 1 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
-(0, 35, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
 (0, 27, date_sub(now(), interval 3 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
 (1, 29, date_sub(now(), interval 1 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
 (0, 32, date_sub(now(), interval 2 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
-(0, 35, date_sub(now(), interval 4 day), '금리가 0.1% 낮아졌습니다.', 'INTEREST_RATE_CHANGE'),
 
 -- 만기 알림 (start_date + 11개월, 만기 7일 전)
 (0, 2, date_add(date_sub(now(), interval 12 month), interval 11 month), '대출 만기 7일 전입니다.', 'MATURITY_NOTICE'),
@@ -348,10 +330,3 @@ values
     (0, 1, 2, now(), '192.168.0.1', 'Chrome-Win', '로그인', '정상 로그인'),
     (1, 2, 3, now(), '192.168.0.2', 'Safari-iOS', '비밀번호 변경', '비밀번호 변경 성공'),
     (0, 0, 4, now(), '192.168.0.3', 'Edge-Win', '로그아웃', '정상 로그아웃');
-
--- AUTHENTICATION
-insert into authentication (authenticated_at, credential_id, member_id, mfa_log_id, ip_address, device_info, auth_method)
-values
-    (now(), 1, 1, 1, '192.168.0.1', 'Chrome-Win', 'FIDO'),
-    (now(), 2, 2, 2, '192.168.0.2', 'Safari-iOS', 'FIDO'),
-    (now(), 3, 3, 3, '192.168.0.3', 'Edge-Win', 'FIDO');


### PR DESCRIPTION
## 🔥 Related Issues

- close #76 

## 💜 작업 내용

- [x] 대출 심사 이력 엔티티 구현 (LoanReviewHistory.java)
- [x] 회원 신용정보 산정 이력 엔티티 구현 (memberCreditSummary.java)
- [x] flyway 버전 관리

## ✅ PR Point

- 회원 신용정보 산정 이력 엔티티(memberCreditSummary.java) 구현
- 대출 심사 이력 엔티티 구현 (LoanReviewHistory.java)
- 데이터베이스 스키마 변경 관리를 위한 Flyway 마이그레이션 스크립트 추가 (V2__add_loan_review_history.sql)

## ☀ 스크린샷 / GIF / 화면 녹화

### 회원이 대출 심사를 받기 전
<img width="1346" alt="전" src="https://github.com/user-attachments/assets/4875db57-e3bf-48e4-ba1a-c6aa4a93950a" />

### 회원이 대출 심사를 받으면, 자동으로 LoanReviewHistory 테이블에도 해당 회원이 대출을 위해 제출한 이력이 저장됩니다.
<img width="1352" alt="후" src="https://github.com/user-attachments/assets/a2bbaa68-8aa4-48d5-a0c4-70f2f7e1efa2" />


## 😡 Trouble Shooting
JPA 엔티티와 데이터베이스 테이블 간 외래 키 컬럼 이름 불일치로 인한 오류가 발생했습니다.
오류 메시지: `Schema-validation: missing column [report_report_id] in table [consumption_habit_category]`

이를 해결해주고자 `@JoinColumn(name = "report_id")`를 명시적으로 지정하여 실제 데이터베이스 컬럼 이름과 매핑을 일치시켰습니다.