### PR TITLE
feat: 사용자 대출 상태 조회 api 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -70,4 +70,19 @@ public class MemberController {
     public ResponseEntity<ConsumeGoalResponse> getConsumeGoal(@PathVariable("consumptionType") ConsumptionType consumptionType) {
         return ResponseEntity.ok(memberService.getConsumeGoal(consumptionType));
     }
+
+    /**
+     * 사용자의 대출 status 조회
+     * @return 대출 상태 (PRE_APPLIED, PENDING, REJECTED, EXECUTED, COMPLETED, NONE)
+     * @since 2025.05.23
+     * @author 권민지
+     */
+    @Operation(summary = "사용자의 대출 상태 조회", description = "사용자의 대출 상태를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "대출 상태 조회 결과 반환"),
+                         @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
+    @GetMapping("/loan-status")
+    public ResponseEntity<String> getLoanStatus(Principal principal) {
+        Long memberId = Long.parseLong(principal.getName());
+        return ResponseEntity.ok(memberService.getLoanStatus(memberId));
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -85,6 +85,25 @@ public class MemberService {
 
     }
 
+    /**
+     * 사용자의 대출 상태 조회
+     * @param memberId 회원 ID
+     * @return 대출 상태 (PRE_APPLIED, PENDING, REJECTED, EXECUTED, COMPLETED, NONE)
+     * @since 2025.05.23
+     * @author 권민지
+     */
+    public String getLoanStatus(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        // member의 LoanApplication이 존재하지 않으면 NONE 반환
+        if (member.getLoanApplication() == null) {
+            return "NONE";
+        }
+
+        return member.getLoanApplication().getStatus().name();
+    }
+
     // 회원 ID로 회원 조회
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)


### PR DESCRIPTION
## 🔥 Related Issues

- close #81 

## 💜 작업 내용

- [x] `GET /loan-status` 로그인 사용자의 대출 상태 조회 api 구현 - 신청서가 존재하지 않을 경우 "NONE"을 반환

## ☀ 스크린샷 / GIF / 화면 녹화
### 인증되지 않은 사용자가 요청할 경우

<img width="376" alt="스크린샷 2025-05-23 10 20 41" src="https://github.com/user-attachments/assets/e0ec7e1d-bd18-4779-8652-d08beb6267f7" />

### 대출 신청 내역이 존재하지 않을 경우 "NONE"

<img width="326" alt="스크린샷 2025-05-23 10 21 54" src="https://github.com/user-attachments/assets/f9bd27f1-77eb-4fa9-86b0-62d0cb4f22fe" />

### 대출 신청을 접수한 경우 "PRE_APPLIED"
<img width="326" alt="스크린샷 2025-05-23 10 22 25" src="https://github.com/user-attachments/assets/13bc0cf6-2d59-45e4-afe3-9ef498ff2524" />


### 신용점수 산정이 완료된 경우 "PENDING"

<img width="288" alt="스크린샷 2025-05-23 10 22 46" src="https://github.com/user-attachments/assets/79f506ad-503f-4e22-912a-44fae5eaf9c1" />
