### PR TITLE
Fix : LoanApplication 생성 로직이 회원가입에서 수행되게끔 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -65,6 +65,10 @@ public class LoanApplication {
     @JoinColumn(name = "review_id")
     private LoanReviewHistory reviewHistory; // 대출 심사 이력
 
+    // 대출 상품 등록
+    public void setProduct(LoanProduct product) {
+        this.product = product;
+    }
 
     // 대출 상태 변경
     public void patchStatus(LoanApplicationStatus status) {
@@ -78,13 +82,14 @@ public class LoanApplication {
 
     /**
      * 대출 상태 전환 유효성 체크
-     * 가능한 상태 전환: PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> PRE_APPLIED
+     * 가능한 상태 전환: NONE -> PRE_APPLIED, PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> PRE_APPLIED
      * @param currentStatus 현재 대출 상태
      * @param newStatus 변경할 대출 상태
      * @return true: 유효한 상태 전환, false: 유효하지 않은 상태 전환
      */
     public boolean isTransitionValid(LoanApplicationStatus currentStatus, LoanApplicationStatus newStatus) {
-        return (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
+        return  (currentStatus == LoanApplicationStatus.NONE && newStatus == LoanApplicationStatus.PRE_APPLIED) ||
+                (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
                 (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.COMPLETED) ||
                 (currentStatus == LoanApplicationStatus.COMPLETED && newStatus == LoanApplicationStatus.PRE_APPLIED);
     }
@@ -110,7 +115,6 @@ public class LoanApplication {
     public void patchExecutedAt() {
         this.executedAt = LocalDateTime.now();
     }
-
 
     // 신용 점수 변경
     public void patchCreditScore(int score) {

--- a/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanApplicationStatus.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/enums/LoanApplicationStatus.java
@@ -1,6 +1,7 @@
 package com.flexrate.flexrate_back.loan.enums;
 
 public enum LoanApplicationStatus {
+    NONE,
     PRE_APPLIED,
     PENDING,
     REJECTED,

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -4,6 +4,7 @@ import com.flexrate.flexrate_back.loan.dto.MainPageResponse;
 import com.flexrate.flexrate_back.member.application.MemberService;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import com.flexrate.flexrate_back.member.dto.ConsumeGoalResponse;
+import com.flexrate.flexrate_back.member.dto.CreditScoreStatusResponse;
 import com.flexrate.flexrate_back.member.dto.MypageResponse;
 import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
 import com.flexrate.flexrate_back.member.enums.ConsumptionType;
@@ -116,7 +117,7 @@ public class MemberController {
             responses = {@ApiResponse(responseCode = "200", description = "사용자의 신용점수 평가 여부 반환"),
                     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
     @GetMapping("/credit-score-status")
-    public ResponseEntity<Boolean> getCreditScoreStatus(Principal principal) {
+    public ResponseEntity<CreditScoreStatusResponse> getCreditScoreStatus(Principal principal) {
         Long memberId = Long.parseLong(principal.getName());
 
         return ResponseEntity.ok(memberService.getCreditScoreStatus(memberId));

--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberService.java
@@ -12,6 +12,7 @@ import com.flexrate.flexrate_back.member.domain.Member;
 import com.flexrate.flexrate_back.member.domain.repository.MemberQueryRepository;
 import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import com.flexrate.flexrate_back.member.dto.ConsumeGoalResponse;
+import com.flexrate.flexrate_back.member.dto.CreditScoreStatusResponse;
 import com.flexrate.flexrate_back.member.dto.MypageResponse;
 import com.flexrate.flexrate_back.member.dto.MypageUpdateRequest;
 import com.flexrate.flexrate_back.member.enums.ConsumeGoal;
@@ -126,11 +127,11 @@ public class MemberService {
      * @since 2025.05.26
      * @author 유승한
      */
-    public Boolean getCreditScoreStatus(Long memberId) {
+    public CreditScoreStatusResponse getCreditScoreStatus(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
 
-        return member.getCreditScoreEvaluated();
+        return CreditScoreStatusResponse.builder().creditScoreStatus(member.getCreditScoreEvaluated()).build();
     }
 
 

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/CreditScoreStatusResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/CreditScoreStatusResponse.java
@@ -1,0 +1,7 @@
+package com.flexrate.flexrate_back.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CreditScoreStatusResponse (Boolean creditScoreStatus) {
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #95 

## 💜 작업 내용

- [x] 플로우 차트에 따라 LoanApplication 생성 로직이 registerByPassword에서 수행되게끔 수정

## ✅ PR Point
registerByPassword 에서 LoanApplication 생성 로직이 수행되게끔 수정
```
    @Transactional
    public SignupResponseDTO registerByPassword(SignupPasswordRequestDTO dto) {
        if (memberRepository.existsByEmail(dto.email())) {
            throw new FlexrateException(ErrorCode.EMAIL_ALREADY_REGISTERED);
    public SignupResponseDTO registerByPassword(SignupPasswordRequestDTO dto) {
        Member saved = memberRepository.save(member);
        dummyFinancialDataGenerator.generateDummyFinancialData(saved);

        // LoanApplication 생성
        LoanApplication application = LoanApplication.builder()
                .member(member)
                .status(LoanApplicationStatus.NONE)
                .loanType(LoanType.NEW)
                .loanTransactions(new ArrayList<>())
                .interests(new ArrayList<>())
                .build();

        loanApplicationRepository.save(application);

        return SignupResponseDTO.builder()
                .userId(saved.getMemberId())
                .email(saved.getEmail())
                .build();
    }
```
기존 LoanApplication 생성 로직이 수행되던 selectProduct에서 아래 부분 삭제
```
        Optional<LoanApplication> existing = loanApplicationRepository.findByMember(persistentMember);
        if (existing.isPresent()) {
            LoanApplication app = existing.get();
            if (app.getStatus() == LoanApplicationStatus.PRE_APPLIED) {
                if (app.getInterests() != null) interestRepository.deleteAll(app.getInterests());
                if (app.getLoanTransactions() != null) loanTransactionRepository.deleteAll(app.getLoanTransactions());

                loanApplicationRepository.flush();

                // member 연관관계 제거
                app.unlinkMember();

                loanApplicationRepository.delete(app);

                loanApplicationRepository.flush();
            } else {
                throw new FlexrateException(ErrorCode.LOAN_APPLICATION_ALREADY_EXISTS);
            }

```
**isTransitionValid** 상에 아래 조건 추가
`(currentStatus == LoanApplicationStatus.NONE && newStatus == LoanApplicationStatus.PRE_APPLIED)
`
![image](https://github.com/user-attachments/assets/81cba784-b7a1-470c-921b-8280ceeb5095)

