### PR TITLE
feat: 관리자 고객 대출 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -164,6 +164,6 @@ public class LoanAdminController {
             throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
         }
 
-        return ResponseEntity.ok(loanAdminService.getLoanReviewHistory(loanApplicationId));
+        return ResponseEntity.ok(loanAdminService.getLoanReviewDetail(loanApplicationId));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/api/LoanAdminController.java
@@ -138,4 +138,32 @@ public class LoanAdminController {
 
         return ResponseEntity.ok(loanAdminService.searchLoans(request));
     }
+
+    /**
+     * 대출 심사 이력 및 기본 정보 상세 조회
+     * @param loanApplicationId 대출 신청 ID
+     * @return 대출 심사 이력 및 기본 정보
+     * @since 2025.05.26
+     * @author 권민지
+     */
+    @Operation(summary = "대출 심사 이력 및 기본 정보 상세 조회", description = "관리자가 대출 신청의 심사 이력 및 기본 정보를 조회합니다.",
+            parameters = {
+                @Parameter(name = "loanApplicationId", description = "대출 신청 ID", required = true)
+            },
+            responses = {
+                @ApiResponse(responseCode = "200", description = "대출 심사 이력 및 기본 정보 조회 성공"),
+                @ApiResponse(responseCode = "404", description = "대출 신청을 찾을 수 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"L002\", \"message\": \"대출 정보를 찾을 수 없습니다.\"}")))
+            })
+    @GetMapping("/{loanApplicationId}/detail")
+    public ResponseEntity<LoanReviewDetailResponse> getLoanReviewDetail(
+            @PathVariable("loanApplicationId") Long loanApplicationId,
+            Principal principal
+    ) {
+        // A007 관리자 인증 체크
+        if (!adminAuthChecker.isAdmin(principal)) {
+            throw new FlexrateException(ErrorCode.ADMIN_AUTH_REQUIRED);
+        }
+
+        return ResponseEntity.ok(loanAdminService.getLoanReviewHistory(loanApplicationId));
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -159,4 +159,24 @@ public class LoanAdminService {
                         .toList())
                 .build();
     }
+
+    /**
+     * 대출 심사 이력 및 기본 정보 상세 조회
+     * @param loanApplicationId 대출 신청 ID
+     * @return 대출 심사 이력 및 기본 정보
+     * @since 2025.05.26
+     * @author 권민지
+     */
+    public LoanReviewDetailResponse getLoanReviewHistory(Long loanApplicationId) {
+        // L002 해당 loanApplicationId 존재 여부 체크
+        if (loanApplicationId == null) {
+            throw new FlexrateException(ErrorCode.LOAN_NOT_FOUND);
+        }
+
+        // L002 loanApplication 데이터 존재여부 체크
+        LoanApplication loanApplication = loanApplicationRepository.findById(loanApplicationId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.LOAN_NOT_FOUND));
+
+        return loanApplicationMapper.toLoanReviewDetailResponse(loanApplication);
+    }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanAdminService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 
 @Service
 @RequiredArgsConstructor
@@ -167,7 +168,7 @@ public class LoanAdminService {
      * @since 2025.05.26
      * @author 권민지
      */
-    public LoanReviewDetailResponse getLoanReviewHistory(Long loanApplicationId) {
+    public LoanReviewDetailResponse getLoanReviewDetail(Long loanApplicationId) {
         // L002 해당 loanApplicationId 존재 여부 체크
         if (loanApplicationId == null) {
             throw new FlexrateException(ErrorCode.LOAN_NOT_FOUND);
@@ -177,6 +178,11 @@ public class LoanAdminService {
         LoanApplication loanApplication = loanApplicationRepository.findById(loanApplicationId)
                 .orElseThrow(() -> new FlexrateException(ErrorCode.LOAN_NOT_FOUND));
 
-        return loanApplicationMapper.toLoanReviewDetailResponse(loanApplication);
+        // 가장 최신 Interest 조회
+        Interest latestInterest = loanApplication.getInterests().stream()
+                .max(Comparator.comparing(Interest::getInterestDate))
+                .orElse(null);
+
+        return loanApplicationMapper.toLoanReviewDetailResponse(loanApplication, latestInterest);
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
@@ -1,5 +1,8 @@
 package com.flexrate.flexrate_back.loan.domain;
 
+import com.flexrate.flexrate_back.loan.enums.EmploymentType;
+import com.flexrate.flexrate_back.loan.enums.LoanPurpose;
+import com.flexrate.flexrate_back.loan.enums.ResidenceType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,16 +23,15 @@ public class LoanReviewHistory {
 
     @OneToOne
     @JoinColumn(name = "application_id", nullable = false)
-    private LoanApplication application;                  // 대출 신청서
+    private LoanApplication application;    // 대출 신청서
 
-    @Column(name = "employment_type", length = 30)
-    private String employmentType;                        // 고용형태
-    private Integer annualIncome;                         // 연소득
+    @Enumerated(EnumType.STRING)
+    private EmploymentType employmentType;  // 고용형태
+    @Enumerated(EnumType.STRING)
+    private ResidenceType residenceType;    // 주거형태
+    @Enumerated(EnumType.STRING)
+    private LoanPurpose loanPurpose;        // 대출목적
 
-    @Column(name = "residence_type", length = 30)
-    private String residenceType;                         // 주거형태
-    private Boolean isBankrupt;                           // 개인회생 여부
-
-    @Column(name = "loan_purpose", length = 50)
-    private String loanPurpose;                           // 대출목적
+    private Integer annualIncome;           // 연소득
+    private Boolean isBankrupt;             // 개인회생 여부
 }

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanReviewApplicationRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanReviewApplicationRequest.java
@@ -1,26 +1,26 @@
 package com.flexrate.flexrate_back.loan.dto;
 
-
-import com.flexrate.flexrate_back.loan.domain.LoanProduct;
-import jakarta.validation.constraints.NotBlank;
+import com.flexrate.flexrate_back.loan.enums.EmploymentType;
+import com.flexrate.flexrate_back.loan.enums.LoanPurpose;
+import com.flexrate.flexrate_back.loan.enums.ResidenceType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record LoanReviewApplicationRequest(
 
-        @NotBlank(message = "고용형태(employmentType)은 필수 입력 항목입니다.")
-        String employmentType,
+        @NotNull(message = "고용형태(employmentType)은 필수 입력 항목입니다.")
+        EmploymentType employmentType,
 
         @NotNull(message = "연소득(annualIncome)은 필수 입력 항목입니다.")
         Integer annualIncome,
 
-        @NotBlank(message = "주거 형태(residenceType)는 필수 입력 항목입니다.")
-        String residenceType,
+        @NotNull(message = "주거 형태(residenceType)는 필수 입력 항목입니다.")
+        ResidenceType residenceType,
 
         @NotNull(message = "개인회생 여부(isBankrupt)는 필수 입력 항목입니다.")
         Boolean isBankrupt,
 
-        @NotBlank(message = "대출 목적(loanPurpose)은 필수 입력 항목입니다.")
-        String loanPurpose
+        @NotNull(message = "대출 목적(loanPurpose)은 필수 입력 항목입니다.")
+        LoanPurpose loanPurpose
 ) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanReviewDetailResponse.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/dto/LoanReviewDetailResponse.java
@@ -1,0 +1,41 @@
+package com.flexrate.flexrate_back.loan.dto;
+
+import com.flexrate.flexrate_back.loan.enums.EmploymentType;
+import com.flexrate.flexrate_back.loan.enums.LoanApplicationStatus;
+import com.flexrate.flexrate_back.loan.enums.LoanPurpose;
+import com.flexrate.flexrate_back.loan.enums.ResidenceType;
+import com.flexrate.flexrate_back.member.enums.ConsumeGoal;
+import com.flexrate.flexrate_back.member.enums.ConsumptionType;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record LoanReviewDetailResponse(
+        Long applicationId,                         // 대출 신청 ID - LoanApplication
+        String applicantName,                       // 신청자 - Member
+        LoanApplicationStatus applicationStatus,    // 현재 상태 - LoanApplication
+        ConsumptionType consumptionType,            // 소비 성향 - Member
+        ConsumeGoal consumeGoal,                    // 소비 목표 - Member
+
+        // === 대출 심사 결과 ===
+        LocalDateTime appliedAt,                    // 대출 신청 일자 - LoanApplication
+        float interestRateMax,                      // 금리 범위 (시작) - LoanProduct
+        float interestRateMin,                      // 금리 범위 (끝) - LoanProduct
+        float initialInterestRate,                  // 대출 초기 금리 - Interest
+        float lastInterestRate,                     // 최근 금리 - Interest
+        LocalDate lastInterestDate,                 // 최근 금리 최종 갱신 일자 - Interest
+        int approvedMaxAmount,                      // 대출 가능 한도 - LoanProduct
+        int requestedAmount,                        // 요청 대출 금액 - LoanApplication
+        LocalDateTime repaymentStartDate,           // 요청 상환 기간 시작일 - LoanApplication
+        LocalDateTime repaymentEndDate,             // 요청 상환 기간 종료일 - LoanApplication
+        int repaymentMonths,                        // 요청 상환 기간 개월(요청 상환 기간 종료일 - 시작일)
+
+        // === 대출 신청 정보 ===
+        EmploymentType employmentType,              // 고용 형태 - LoanReviewHistory
+        Integer annualIncome,                       // 연소득 - LoanReviewHistory
+        ResidenceType residenceType,                // 주거 형태 - LoanReviewHistory
+        Boolean isBankrupt,                         // 개인회생 여부 - LoanReviewHistory
+        LoanPurpose loanPurpose                     // 대출 목적 - LoanReviewHistory
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanApplicationMapper.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanApplicationMapper.java
@@ -42,7 +42,8 @@ public class LoanApplicationMapper {
                 .repaymentStartDate(loan.getStartDate())
                 .repaymentEndDate(loan.getEndDate())
                 .repaymentMonths(
-                        (int) java.time.temporal.ChronoUnit.MONTHS.between(loan.getStartDate(), loan.getEndDate())
+                        loan.getStartDate() != null && loan.getEndDate() != null ?
+                                (int) java.time.temporal.ChronoUnit.MONTHS.between(loan.getStartDate(), loan.getEndDate()) : 0
                 )
 
                 .employmentType(loan.getReviewHistory() != null ? loan.getReviewHistory().getEmploymentType() : null)

--- a/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanApplicationMapper.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/mapper/LoanApplicationMapper.java
@@ -1,7 +1,9 @@
 package com.flexrate.flexrate_back.loan.mapper;
 
+import com.flexrate.flexrate_back.loan.domain.Interest;
 import com.flexrate.flexrate_back.loan.domain.LoanApplication;
 import com.flexrate.flexrate_back.loan.dto.LoanAdminSearchSummaryDto;
+import com.flexrate.flexrate_back.loan.dto.LoanReviewDetailResponse;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,6 +20,36 @@ public class LoanApplicationMapper {
                 .initialRate(loan.getRate())
                 .prevLoanCount(loan.getLoanTransactions().size())
                 .type(loan.getLoanType() != null ? loan.getLoanType().name() : null)
+                .build();
+    }
+
+    public LoanReviewDetailResponse toLoanReviewDetailResponse(LoanApplication loan, Interest interest) {
+        return LoanReviewDetailResponse.builder()
+                .applicationId(loan.getApplicationId())
+                .applicantName(loan.getMember().getName())
+                .applicationStatus(loan.getStatus())
+                .consumptionType(loan.getMember().getConsumptionType())
+                .consumeGoal(loan.getMember().getConsumeGoal())
+
+                .appliedAt(loan.getAppliedAt())
+                .approvedMaxAmount(loan.getProduct().getMaxAmount())
+                .interestRateMax(loan.getProduct().getMaxRate())
+                .interestRateMin(loan.getProduct().getMinRate())
+                .initialInterestRate(loan.getRate())
+                .lastInterestRate(interest != null ? interest.getInterestRate() : 0.0f)
+                .lastInterestDate(interest != null ? interest.getInterestDate() : null)
+                .requestedAmount(loan.getTotalAmount())
+                .repaymentStartDate(loan.getStartDate())
+                .repaymentEndDate(loan.getEndDate())
+                .repaymentMonths(
+                        (int) java.time.temporal.ChronoUnit.MONTHS.between(loan.getStartDate(), loan.getEndDate())
+                )
+
+                .employmentType(loan.getReviewHistory() != null ? loan.getReviewHistory().getEmploymentType() : null)
+                .annualIncome(loan.getReviewHistory() != null ? loan.getReviewHistory().getAnnualIncome() : null)
+                .residenceType(loan.getReviewHistory() != null ? loan.getReviewHistory().getResidenceType() : null)
+                .isBankrupt(loan.getReviewHistory() != null ? loan.getReviewHistory().getIsBankrupt() : null)
+                .loanPurpose(loan.getReviewHistory() != null ? loan.getReviewHistory().getLoanPurpose() : null)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #92 

## 💜 작업 내용
### 아래 페이지 모달에 필요한 데이터 조회 API 구현
![image](https://github.com/user-attachments/assets/bdb3aa16-0169-4035-90e5-712af081186f)

- [x] 고객 대출 상세 정보 조회 API 구현
- [x] `LoanReviewHistory`에서 문자열 필드(`employmentType`, `residenceType`, `loanPurpose`)를 ENUM(`EmploymentType`, `ResidenceType`, `LoanPurpose`)으로 변경

## ☀ 스크린샷 / GIF / 화면 녹화
### 대출 신청 정보가 없을 경우 관련 데이터 null 또는 0 반환
![image](https://github.com/user-attachments/assets/3119e4cc-8c2d-4ff3-9b66-34e6ca68ffb5)

### 모든 정보가 있을 경우
![image](https://github.com/user-attachments/assets/b93ade6f-a144-4a25-910c-aea81e92e8f8)




