### PR TITLE
fix : 특정 회원의 지정 월에 대한 카테고리별 소비 통계 조회 json type으로 저장하고, 재호출 시 저장된 데이터 반환

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     REPORT_MEMBER_OR_MONTH_NULL("R001", "member 또는 month는 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
     REPORT_ALREADY_EXISTS("R002", "해당 월의 소비습관 리포트가 이미 존재합니다.", HttpStatus.CONFLICT),
     NO_CONSUMPTION_DATA("R003", "해당 월의 소비데이터가 존재하지 않습니다.", HttpStatus.CONFLICT),
+    REPORT_DOESNT_EXISTS("R004", "해당 월의 소비습관 리포트가 존재하지 않습니다.", HttpStatus.CONFLICT),
+    JSON_SERIALIZATION_ERROR("R005", "소비 데이터 직렬화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    JSON_DESERIALIZATION_ERROR("R006", "소비 데이터 역직렬화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // GPT
     OPENAI_ERROR("GPT001", "OpenAI API 통신 오류", HttpStatus.CONFLICT),

--- a/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitReport.java
+++ b/src/main/java/com/flexrate/flexrate_back/report/domain/ConsumptionHabitReport.java
@@ -45,4 +45,9 @@ public class ConsumptionHabitReport {
     private LocalDate createdAt;
 
     private String consumptions;
+
+    public void setConsumptions(String consumptions) {
+        this.consumptions = consumptions;
+    }
+
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #98 

## 💜 작업 내용

- [x] 특정 회원의 지정 월에 대한 카테고리별 소비 통계 조회 json type으로 저장하고, 재호출 시 저장된 데이터 반환

## ✅ PR Point

```
  public ConsumptionCategoryStatsResponse getCategoryStats(Member member, YearMonth month) {
      ConsumptionHabitReport report = reportRepository.findByMemberAndReportMonth(member, month)
              .orElseThrow(() -> new FlexrateException(ErrorCode.REPORT_DOESNT_EXISTS));

      List<ConsumptionCategoryRatioResponse> stats;

      // consumptions가 비어 있거나 null이면 계산 및 json type으로 직렬화하여 저장
      if (report.getConsumptions() == null || report.getConsumptions().isBlank()) {
          stats = financialDataRepository.findCategoryStatsWithRatio(member, month);

          try {
              String consumptionsJson = objectMapper.writeValueAsString(stats);
              report.setConsumptions(consumptionsJson);
              reportRepository.save(report);
          } catch (JsonProcessingException e) {
              throw new FlexrateException(ErrorCode.JSON_SERIALIZATION_ERROR, e);
          }
      } else {
          // consumptions가 존재할 시 consumptions를 비직렬화하여 반환
          try {
              stats = objectMapper.readValue(
                      report.getConsumptions(),
                      new TypeReference<>() {}
              );
          } catch (JsonProcessingException e) {
              throw new FlexrateException(ErrorCode.JSON_DESERIALIZATION_ERROR, e);
          }
      }
      return new ConsumptionCategoryStatsResponse(
              member.getMemberId(),
              month,
              stats
      );
  }

```

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/user-attachments/assets/61a452ee-fa42-45ac-8c3d-99463f9cfe74)