### PR TITLE
fix: 대출 상태 전환 유효성 체크 로직 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -82,17 +82,23 @@ public class LoanApplication {
 
     /**
      * 대출 상태 전환 유효성 체크
-     * 가능한 상태 전환: NONE -> PRE_APPLIED, PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> PRE_APPLIED
+     * 가능한 상태 전환: NONE -> PRE_APPLIED, PRE_APPLIED -> NONE, PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> NONE, REJECTED -> NONE
+     * - NONE: 대출 상품 선택 전
+     * - PRE_APPLIED: 신청 접수 중
+     * - PENDING: 심사 중
      * @param currentStatus 현재 대출 상태
      * @param newStatus 변경할 대출 상태
      * @return true: 유효한 상태 전환, false: 유효하지 않은 상태 전환
      */
     public boolean isTransitionValid(LoanApplicationStatus currentStatus, LoanApplicationStatus newStatus) {
         return  (currentStatus == LoanApplicationStatus.NONE && newStatus == LoanApplicationStatus.PRE_APPLIED) ||
+                (currentStatus == LoanApplicationStatus.PRE_APPLIED && newStatus == LoanApplicationStatus.NONE) ||
                 (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
                 (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.COMPLETED) ||
-                (currentStatus == LoanApplicationStatus.COMPLETED && newStatus == LoanApplicationStatus.PRE_APPLIED);
+                (currentStatus == LoanApplicationStatus.COMPLETED && newStatus == LoanApplicationStatus.NONE) ||
+                (currentStatus == LoanApplicationStatus.REJECTED && newStatus == LoanApplicationStatus.NONE);
     }
+
     /**
      * 대출 심사 결과 반영
      *


### PR DESCRIPTION
## 🔥 Related Issues

- close #100 

## 💜 작업 내용

- [x] `LoanApplication` 도메인 클래스 대출 신청 상태 전환 로직 업데이트

## ✅ PR Point

유효한 상태 전환 목록을 아래와 같이 확장하였습니다.
  - `PRE_APPLIED -> NONE`
  - `COMPLETED -> NONE`
  - `REJECTED -> NONE`  
