### PR TITLE
fix: LoginResponseDTO 수정 및 EmailController PostMapping URL 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/auth/api/EmailController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/EmailController.java
@@ -28,7 +28,7 @@ public class EmailController {
      * 주어진 이메일로 인증 확인 메일을 보내는 메서드이다.
      * @param request 이메일이 포함된 DTO
      */
-    @PostMapping
+    @PostMapping("/send")
     @Operation(summary = "인증메일 발송", description = "인증 확인 메일을 보내는 API", responses = {
             @ApiResponse(responseCode = "200", description = "성공"),
     })

--- a/src/main/java/com/flexrate/flexrate_back/member/application/LoginService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/LoginService.java
@@ -53,6 +53,7 @@ public class LoginService {
 
         return LoginResponseDTO.builder()
                 .userId(member.getMemberId())
+                .username(member.getName())
                 .email(member.getEmail())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -90,6 +91,7 @@ public class LoginService {
 
         return LoginResponseDTO.builder()
                 .userId(member.getMemberId())
+                .username(member.getName())
                 .email(member.getEmail())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -122,6 +124,7 @@ public class LoginService {
 
         return LoginResponseDTO.builder()
                 .userId(member.getMemberId())
+                .username(member.getName())
                 .email(member.getEmail())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/LoginResponseDTO.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/LoginResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record LoginResponseDTO(
         Long userId,
+        String username,
         String email,
         String accessToken,
         String refreshToken,


### PR DESCRIPTION
## 🔥 Related Issues

- close #103 

## 💜 작업 내용

- [x] LoginResponseDTO에서 username을 추가하였습니다.
- [x] 이에 맞게 LoginService에서 username을 반환하도록 하였습니다.
- [x] EmailController에 빠져있던 PostMapping URL 지정을 `/send`로 하였습니다.
