### PR TITLE
fix: 로그인 요청 성공 시, refreshToken httpOnly 쿠키로 내려주도록 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/api/LoginController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/LoginController.java
@@ -6,8 +6,11 @@ import com.flexrate.flexrate_back.member.dto.MfaLoginRequestDTO;
 import com.flexrate.flexrate_back.member.dto.PasskeyLoginRequestDTO;
 import com.flexrate.flexrate_back.member.dto.PasswordLoginRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,10 +27,26 @@ public class LoginController {
             tags = { "Auth Controller" }
     )
     @PostMapping("/login/password")
-    public ResponseEntity<LoginResponseDTO> loginWithPassword(@RequestBody @Valid PasswordLoginRequestDTO request) {
-        LoginResponseDTO response = loginService.loginWithPassword(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<LoginResponseDTO> loginWithPassword(
+            @RequestBody @Valid PasswordLoginRequestDTO request,
+            HttpServletResponse response
+    ) {
+        LoginResponseDTO loginResponse = loginService.loginWithPassword(request);
+
+        String refreshToken = loginResponse.refreshToken();
+
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .secure(false) // <---- https일 시, true로 변경하기!
+                .path("/")
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok(loginResponse);
     }
+
 
     @Operation(
             summary = "Passkey 로그인",


### PR DESCRIPTION
## 🔥 Related Issues

- close #117 

## 💜 작업 내용

- [x] 로그인 요청 성공 시, refreshToken httpOnly 쿠키로 내려주도록 관련 로직 수정

## ✅ PR Point

- 로그인 시, 리프레쉬 토큰을 반환하지만 이를 httpOnly 쿠키로 전달하는 과정이 빠져있어서 관련하여 로직을 추가하였습니다. 
- 이후 프론트에서 서버에게 받은 쿠키 리프레쉬 토큰을 서버에 /api/auth/token api 요청 시, 자동으로 전달할 수 있습니다.
```java
 public ResponseEntity<LoginResponseDTO> loginWithPassword(
            @RequestBody @Valid PasswordLoginRequestDTO request,
            HttpServletResponse response
    ) {
        LoginResponseDTO loginResponse = loginService.loginWithPassword(request);

        String refreshToken = loginResponse.refreshToken();

        ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
                .httpOnly(true)
                .secure(false) // <---- https일 시, true로 변경하기!
                .path("/")
                .sameSite("Lax")
                .build();

        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

        return ResponseEntity.ok(loginResponse);
    }
```

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/user-attachments/assets/28a7944a-5039-4e75-8a26-8bc5657ab7c0)
