### PR TITLE
fix: 대출 심사 결과 갱신 메서드 추가 및 대출 신청 사전 정보 저장 로직 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanService.java
@@ -129,14 +129,26 @@ public class LoanService {
                 .build();
 
         // 대출 신청 사전 정보 저장
-        LoanReviewHistory loanReviewHistory = LoanReviewHistory.builder()
-                .employmentType(request.employmentType())
-                .annualIncome(request.annualIncome())
-                .residenceType(request.residenceType())
-                .isBankrupt(request.isBankrupt())
-                .loanPurpose(request.loanPurpose())
-                .application(loanApplication)
-                .build();
+        LoanReviewHistory loanReviewHistory = loanApplication.getReviewHistory();
+
+        if (loanReviewHistory != null) {
+            loanReviewHistory.updateReview(
+                    request.employmentType(),
+                    request.residenceType(),
+                    request.loanPurpose(),
+                    request.annualIncome(),
+                    request.isBankrupt()
+            );
+        } else {
+            loanReviewHistory = LoanReviewHistory.builder()
+                    .employmentType(request.employmentType())
+                    .annualIncome(request.annualIncome())
+                    .residenceType(request.residenceType())
+                    .isBankrupt(request.isBankrupt())
+                    .loanPurpose(request.loanPurpose())
+                    .application(loanApplication)
+                    .build();
+        }
 
         loanReviewHistoryRepository.save(loanReviewHistory);
         loanApplication.applyReviewResult(externalResponse, loanReviewHistory);

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanReviewHistory.java
@@ -34,4 +34,14 @@ public class LoanReviewHistory {
 
     private Integer annualIncome;           // 연소득
     private Boolean isBankrupt;             // 개인회생 여부
+
+    // 대출 심사 결과 갱신
+    public void updateReview(EmploymentType employmentType, ResidenceType residenceType,
+                             LoanPurpose loanPurpose, Integer annualIncome, Boolean isBankrupt) {
+        this.employmentType = employmentType;
+        this.residenceType = residenceType;
+        this.loanPurpose = loanPurpose;
+        this.annualIncome = annualIncome;
+        this.isBankrupt = isBankrupt;
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #119 

## 💜 작업 내용

- [x] 기존 대출 심사 이력 업데이트 가능하도록 대출 신청 프로세스에 update 로직 추가

## ✅ PR Point

- `LoanService.java`
   - `preApply` 메서드를 업데이트하여 대출 신청에 대한 `LoanReviewHistory`가 이미 존재하는지 확인하도록 변경. 
   - 존재할 경우, 새로운 `updateReview` 메서드를 사용해 심사 세부 정보를 업데이트하고, 그렇지 않을 경우 이전과 동일하게 새로운 `LoanReviewHistory`를 생성
- `LoanReviewHistory.java`
   - 기존 대출 심사 세부 정보를 업데이트할 수 있도록 새로운 `updateReview` 메서드 추가

```
    // 대출 심사 결과 갱신
    public void updateReview(EmploymentType employmentType, ResidenceType residenceType,
                             LoanPurpose loanPurpose, Integer annualIncome, Boolean isBankrupt) {
        this.employmentType = employmentType;
        this.residenceType = residenceType;
        this.loanPurpose = loanPurpose;
        this.annualIncome = annualIncome;
        this.isBankrupt = isBankrupt;
    }
```
