### PR TITLE
fix: 로그아웃 refreshToken 쿠키로 요청 받도록 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/api/LoginController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/LoginController.java
@@ -76,8 +76,20 @@ public class LoginController {
             tags = { "Auth Controller" }
     )
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@CookieValue(value = "refresh_token") String refreshToken) {
-        loginService.logout(refreshToken);
+    public ResponseEntity<String> logout(@CookieValue(value = "refresh_token") String refreshToken, HttpServletResponse response) {
+
+        if(refreshToken != null) {
+            loginService.logout(refreshToken);
+
+            ResponseCookie deleteCookie = ResponseCookie.from("refresh_token", "")
+                    .httpOnly(true)
+                    .secure(false) // <---- https일 시, true로 변경하기!
+                    .path("/")
+                    .maxAge(0)
+                    .build();
+
+            response.setHeader("Set-Cookie", deleteCookie.toString());
+        }
         return ResponseEntity.ok("로그아웃");
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/api/LoginController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/LoginController.java
@@ -76,7 +76,7 @@ public class LoginController {
             tags = { "Auth Controller" }
     )
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(@RequestParam String refreshToken) {
+    public ResponseEntity<String> logout(@CookieValue(value = "refresh_token") String refreshToken) {
         loginService.logout(refreshToken);
         return ResponseEntity.ok("로그아웃");
     }


### PR DESCRIPTION
## 🔥 Related Issues

- close #126 

## 💜 작업 내용

- [x] 로그아웃 refreshToken 쿠키로 요청 받도록 수정

## ✅ PR Point

- 기존 쿼리로 리프레쉬 토큰을 요청받았던 문제를 해결하기 위해 쿠키로 요청 받는 방식으로 수정합니다.

## ☀ 스크린샷 / GIF / 화면 녹화
<img width="790" alt="image" src="https://github.com/user-attachments/assets/5bdb9e5a-716e-4f55-b704-08992d26015a" />

