### PR TITLE
feat: MFA PIN 도입

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/auth/api/AuthController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/AuthController.java
@@ -1,0 +1,46 @@
+package com.flexrate.flexrate_back.auth.api;
+
+import com.flexrate.flexrate_back.auth.application.AuthService;
+import com.flexrate.flexrate_back.auth.dto.PinRequest;
+import com.flexrate.flexrate_back.member.application.MemberService;
+import com.flexrate.flexrate_back.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+/**
+ * PIN 인증 API 컨트롤러
+ *
+ * @since 2025.05.31
+ * @author 권민지
+ */
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final MemberService memberService;
+    private final AuthService authService;
+
+    @Operation(
+            summary = "사용자 PIN 보유 여부 조회",
+            description = "로그인된 사용자의 PIN 보유 여부를 조회합니다."
+    )
+    @GetMapping("/pin/registered")
+    public ResponseEntity<Boolean> checkPinRegistered(Principal principal) {
+        Member member = memberService.findById(Long.parseLong(principal.getName()));
+        return ResponseEntity.ok(authService.checkPinRegistered(member));
+    }
+
+    @Operation(
+            summary = "입력 PIN 인증",
+            description = "로그인된 사용자가 입력한 PIN이 등록된 PIN과 일치하는지 확인합니다."
+    )
+    @PostMapping("/pin/verify")
+    public ResponseEntity<Boolean> verifyPin(@RequestBody PinRequest pinRequest, Principal principal) {
+        Member member = memberService.findById(Long.parseLong(principal.getName()));
+        return ResponseEntity.ok(authService.verifyPin(pinRequest, member));
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/api/AuthController.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/api/AuthController.java
@@ -2,6 +2,8 @@ package com.flexrate.flexrate_back.auth.api;
 
 import com.flexrate.flexrate_back.auth.application.AuthService;
 import com.flexrate.flexrate_back.auth.dto.PinRequest;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.member.application.MemberService;
 import com.flexrate.flexrate_back.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +32,10 @@ public class AuthController {
     )
     @GetMapping("/pin/registered")
     public ResponseEntity<Boolean> checkPinRegistered(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
+
         Member member = memberService.findById(Long.parseLong(principal.getName()));
         return ResponseEntity.ok(authService.checkPinRegistered(member));
     }
@@ -40,6 +46,10 @@ public class AuthController {
     )
     @PostMapping("/pin/verify")
     public ResponseEntity<Boolean> verifyPin(@RequestBody PinRequest pinRequest, Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
+
         Member member = memberService.findById(Long.parseLong(principal.getName()));
         return ResponseEntity.ok(authService.verifyPin(pinRequest, member));
     }

--- a/src/main/java/com/flexrate/flexrate_back/auth/application/AuthService.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/application/AuthService.java
@@ -1,0 +1,77 @@
+package com.flexrate.flexrate_back.auth.application;
+
+import com.flexrate.flexrate_back.auth.domain.PinCredential;
+import com.flexrate.flexrate_back.auth.domain.repository.PinCredentialRepository;
+import com.flexrate.flexrate_back.auth.dto.PinRequest;
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
+import com.flexrate.flexrate_back.member.domain.Member;
+import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+    private final PinCredentialRepository pinCredentialRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 로그인된 사용자의 PIN 등록 여부 확인
+     * @param member 로그인된 사용자 정보
+     */
+    public boolean checkPinRegistered(Member member) {
+        boolean present = pinCredentialRepository.findByMember_MemberId(member.getMemberId()).isPresent();
+        log.debug("PIN 등록 여부: memberId={}, registered={}", member.getMemberId(), present);
+
+        return present;
+    }
+
+    /**
+     * PIN 등록
+     * @param pin PIN 등록 요청 정보
+     * @param userId 로그인된 사용자 ID
+     */
+    @Transactional
+    public void registerPin(String pin, Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new FlexrateException(ErrorCode.USER_NOT_FOUND));
+
+        if (pinCredentialRepository.findByMember_MemberId(member.getMemberId()).isPresent()) {
+            log.warn("PIN 이미 등록된 사용자: memberId={}", member.getMemberId());
+            throw new FlexrateException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        String hashedPin = passwordEncoder.encode(pin);
+        PinCredential pinCredential = PinCredential.builder()
+                .member(member)
+                .pinHash(hashedPin)
+                .build();
+
+        pinCredentialRepository.save(pinCredential);
+    }
+
+    /**
+     * PIN 인증
+     * @param pinRequest PIN 인증 요청 정보
+     * @param member 로그인된 사용자 정보
+     */
+    public boolean verifyPin(PinRequest pinRequest, Member member) {
+        PinCredential pinCredential = pinCredentialRepository.findByMember_MemberId(member.getMemberId())
+                .orElseThrow(() -> {
+                    log.warn("PIN 인증 실패: 등록되지 않은 사용자 PIN, memberId={}", member.getMemberId());
+                    return new FlexrateException(ErrorCode.PIN_NOT_REGISTERED);
+                });
+
+        boolean isValid = passwordEncoder.matches(pinRequest.pin(), pinCredential.getPinHash());
+        log.debug("PIN 인증 결과: memberId={}, isValid={}", member.getMemberId(), isValid);
+
+        return isValid;
+    }
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/PinCredential.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/PinCredential.java
@@ -1,0 +1,24 @@
+package com.flexrate.flexrate_back.auth.domain;
+
+import com.flexrate.flexrate_back.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PinCredential {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false)
+    private String pinHash;
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/domain/repository/PinCredentialRepository.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/domain/repository/PinCredentialRepository.java
@@ -1,0 +1,10 @@
+package com.flexrate.flexrate_back.auth.domain.repository;
+
+import com.flexrate.flexrate_back.auth.domain.PinCredential;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PinCredentialRepository extends JpaRepository<PinCredential, Long> {
+    Optional<PinCredential> findByMember_MemberId(Long memberId);
+}

--- a/src/main/java/com/flexrate/flexrate_back/auth/dto/PinRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/dto/PinRequest.java
@@ -1,5 +1,10 @@
 package com.flexrate.flexrate_back.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record PinRequest(
+        @NotBlank(message = "pin은 필수 항목입니다.")
+        @Pattern(regexp = "\\d{6}", message = "PIN은 6자리 숫자여야 합니다.")
         String pin
 ) {}

--- a/src/main/java/com/flexrate/flexrate_back/auth/dto/PinRequest.java
+++ b/src/main/java/com/flexrate/flexrate_back/auth/dto/PinRequest.java
@@ -1,0 +1,5 @@
+package com.flexrate.flexrate_back.auth.dto;
+
+public record PinRequest(
+        String pin
+) {}

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
     ADMIN_AUTH_REQUIRED("A007", "관리자 권한이 필요합니다.", HttpStatus.FORBIDDEN),
     REFRESH_TOKEN_NOT_FOUND("A008", "리프레쉬 토큰이 누락되었습니다.", HttpStatus.BAD_REQUEST),
     PIN_NOT_REGISTERED("A009", "PIN이 등록되어 있지 않습니다.", HttpStatus.UNAUTHORIZED),
+    UNAUTHORIZED("A010", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
 
     // 상품
     PRODUCT_LOAD_ERROR("P001", "상품을 불러오는 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
+++ b/src/main/java/com/flexrate/flexrate_back/common/exception/ErrorCode.java
@@ -17,7 +17,6 @@ public enum ErrorCode {
     USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DUPLICATED_EMAIL("U002", "이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
 
-
     // 대출
     INVALID_APPLICATION("L001", "신청 정보가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     LOAN_NOT_FOUND("L002", "대출 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
@@ -60,6 +59,7 @@ public enum ErrorCode {
     AUTHENTICATION_REQUIRED("A006", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     ADMIN_AUTH_REQUIRED("A007", "관리자 권한이 필요합니다.", HttpStatus.FORBIDDEN),
     REFRESH_TOKEN_NOT_FOUND("A008", "리프레쉬 토큰이 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    PIN_NOT_REGISTERED("A009", "PIN이 등록되어 있지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     // 상품
     PRODUCT_LOAD_ERROR("P001", "상품을 불러오는 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/api/MemberController.java
@@ -1,8 +1,9 @@
 package com.flexrate.flexrate_back.member.api;
 
+import com.flexrate.flexrate_back.common.exception.ErrorCode;
+import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.loan.dto.MainPageResponse;
 import com.flexrate.flexrate_back.member.application.MemberService;
-import com.flexrate.flexrate_back.member.domain.repository.MemberRepository;
 import com.flexrate.flexrate_back.member.dto.ConsumeGoalResponse;
 import com.flexrate.flexrate_back.member.dto.CreditScoreStatusResponse;
 import com.flexrate.flexrate_back.member.dto.MypageResponse;
@@ -22,7 +23,6 @@ import java.security.Principal;
 @RequestMapping("/api/members")
 public class MemberController {
     private final MemberService memberService;
-    private final MemberRepository memberRepository;
 
     /**
      * 메인페이지 조회
@@ -36,10 +36,13 @@ public class MemberController {
                     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
     @GetMapping("/main")
     public ResponseEntity<MainPageResponse> getMainPage(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.getMainPage(memberId));
     }
-
 
     /**
      * 마이페이지 조회
@@ -53,6 +56,10 @@ public class MemberController {
                          @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
     @GetMapping("/mypage")
     public ResponseEntity<MypageResponse> getMyPage(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.getMyPage(memberId));
     }
@@ -73,6 +80,10 @@ public class MemberController {
             @Valid @RequestBody MypageUpdateRequest request,
             Principal principal
     ) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.updateMyPage(memberId, request));
     }
@@ -103,6 +114,10 @@ public class MemberController {
                          @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
     @GetMapping("/loan-status")
     public ResponseEntity<String> getLoanStatus(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.getLoanStatus(memberId));
     }
@@ -118,8 +133,11 @@ public class MemberController {
                     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")})
     @GetMapping("/credit-score-status")
     public ResponseEntity<CreditScoreStatusResponse> getCreditScoreStatus(Principal principal) {
-        Long memberId = Long.parseLong(principal.getName());
+        if (principal == null || principal.getName() == null) {
+            throw new FlexrateException(ErrorCode.UNAUTHORIZED);
+        }
 
+        Long memberId = Long.parseLong(principal.getName());
         return ResponseEntity.ok(memberService.getCreditScoreStatus(memberId));
     }
 }

--- a/src/main/java/com/flexrate/flexrate_back/member/application/SignupService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/SignupService.java
@@ -1,5 +1,6 @@
 package com.flexrate.flexrate_back.member.application;
 
+import com.flexrate.flexrate_back.auth.application.AuthService;
 import com.flexrate.flexrate_back.common.exception.ErrorCode;
 import com.flexrate.flexrate_back.common.exception.FlexrateException;
 import com.flexrate.flexrate_back.loan.application.repository.LoanApplicationRepository;
@@ -17,6 +18,7 @@ import com.flexrate.flexrate_back.member.enums.MemberStatus;
 import com.flexrate.flexrate_back.member.enums.Role;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +27,7 @@ import java.time.Period;
 import java.util.ArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SignupService {
@@ -34,12 +37,13 @@ public class SignupService {
     private final WebAuthnService webAuthnService;
     private final DummyFinancialDataGenerator dummyFinancialDataGenerator;
     private final LoanApplicationRepository loanApplicationRepository;
-
+    private final AuthService authService;
 
     // 비밀번호 기반 회원가입
     @Transactional
     public SignupResponseDTO registerByPassword(SignupPasswordRequestDTO dto) {
         if (memberRepository.existsByEmail(dto.email())) {
+            log.warn("이미 등록된 이메일로 회원가입 시도: email={}", dto.email());
             throw new FlexrateException(ErrorCode.EMAIL_ALREADY_REGISTERED);
         }
 
@@ -60,9 +64,14 @@ public class SignupService {
                 .build();
 
         Member saved = memberRepository.save(member);
-        dummyFinancialDataGenerator.generateDummyFinancialData(saved);
+        log.debug("회원 DB 저장 성공: memberId={}, email={}", saved.getMemberId(), saved.getEmail());
 
-        // LoanApplication 생성
+        authService.registerPin(dto.pin(), saved.getMemberId());
+        log.debug("회원 PIN 등록 완료: memberId={}", saved.getMemberId());
+
+        dummyFinancialDataGenerator.generateDummyFinancialData(saved);
+        log.debug("회원 금융 데이터 생성 완료: memberId={}", saved.getMemberId());
+
         LoanApplication application = LoanApplication.builder()
                 .member(member)
                 .status(LoanApplicationStatus.NONE)
@@ -72,8 +81,7 @@ public class SignupService {
                 .build();
 
         loanApplicationRepository.save(application);
-
-
+        log.debug("회원 대출 신청 객체 생성 완료: memberId={}, applicationId={}", saved.getMemberId(), application.getApplicationId());
 
         return SignupResponseDTO.builder()
                 .userId(saved.getMemberId())
@@ -81,6 +89,11 @@ public class SignupService {
                 .build();
     }
 
+    /**
+     * FIDO(패스키) 등록
+     * @param memberId 회원 ID
+     * @param dto 패스키 등록 요청 정보
+     */
     @Transactional
     public void addFidoCredential(Long memberId, PasskeyRequestDTO dto) {
         Member member = memberRepository.findById(memberId)
@@ -98,6 +111,8 @@ public class SignupService {
         ConsumptionType[] types = ConsumptionType.values();
         int randomIndex = ThreadLocalRandom.current().nextInt(types.length);
         ConsumptionType randomType = types[randomIndex];
+
+        log.debug("소비타입 분석 결과: consumptionType={}", randomType);
 
         return AnalyzeConsumptionTypeResponse.builder()
                 .consumptionType(randomType)

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/SignupPasswordRequestDTO.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/SignupPasswordRequestDTO.java
@@ -36,5 +36,8 @@ public record SignupPasswordRequestDTO(
         ConsumptionType consumptionType,
 
         @NotNull(message = "소비 목표는 필수 항목입니다.")
-        ConsumeGoal consumeGoal
+        ConsumeGoal consumeGoal,
+
+        @NotBlank(message = "pin은 필수 항목입니다.")
+        String pin
 ) {}

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/SignupPasswordRequestDTO.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/SignupPasswordRequestDTO.java
@@ -8,6 +8,7 @@ import com.flexrate.flexrate_back.member.enums.Sex;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -39,5 +40,6 @@ public record SignupPasswordRequestDTO(
         ConsumeGoal consumeGoal,
 
         @NotBlank(message = "pin은 필수 항목입니다.")
+        @Pattern(regexp = "\\d{6}", message = "PIN은 6자리 숫자여야 합니다.")
         String pin
 ) {}


### PR DESCRIPTION
## 🔥 Related Issues

- close #125 

## 💜 작업 내용

- [x] PIN 인증 API 구현
- [x] 회원가입 로직에 PIN 인증 추가
- [x] PIN 유효성 검사 강화 (숫자 6자리만 가능)

## ☀ 스크린샷 / GIF / 화면 녹화
### 회원가입 - PIN을 숫자 외의 값으로 입력한 경우 (V001 error)
![image](https://github.com/user-attachments/assets/9c76d015-4aee-4a8c-b53c-66e2ea181f95)

### 정상적으로 회원가입 된 경우
![image](https://github.com/user-attachments/assets/7f0eb627-9971-4d5c-b81f-abbd8f1a4635)
![image](https://github.com/user-attachments/assets/fb657a5a-da21-4a36-a425-4e01e62a7b55)

### PIN 인증이 정상적으로 완료된 경우 - true 반환
![image](https://github.com/user-attachments/assets/4738d143-def0-4b4f-9fd1-53c15345178a)
![image](https://github.com/user-attachments/assets/74ebe457-505a-45c2-9e72-1fe2a7ddd911)

### PIN을 잘못 입력한 경우 - false 반환
![image](https://github.com/user-attachments/assets/776fbe5f-ddfd-46be-845f-add8f6d5baf5)

### 로그인 없이 PIN 인증을 시도한 경우
![image](https://github.com/user-attachments/assets/806310a1-bbb2-49fe-b9e1-9a307e183395)
