### PR TITLE
fix: LoginResponseDTO role 추가 및 재신청 시, REJECTED -> PRE_APPLIED 상태 변경 허용

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/loan/application/LoanProductService.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/application/LoanProductService.java
@@ -86,7 +86,7 @@ public class LoanProductService {
                     return new FlexrateException(ErrorCode.LOAN_NOT_FOUND);
                 });
 
-        if (app.getStatus() != LoanApplicationStatus.NONE) {
+        if (app.getStatus() != LoanApplicationStatus.NONE && app.getStatus() !=  LoanApplicationStatus.REJECTED) {
             log.warn("대출 상품 선택 실패:\n이미 신청된 대출 존재, memberId={}, status={}", persistentMember.getMemberId(), app.getStatus());
             throw new FlexrateException(ErrorCode.LOAN_APPLICATION_ALREADY_EXISTS);
         }

--- a/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
+++ b/src/main/java/com/flexrate/flexrate_back/loan/domain/LoanApplication.java
@@ -81,7 +81,7 @@ public class LoanApplication {
 
     /**
      * 대출 상태 전환 유효성 체크
-     * 가능한 상태 전환: NONE -> PRE_APPLIED, PRE_APPLIED -> NONE, PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> NONE, REJECTED -> NONE
+     * 가능한 상태 전환: NONE -> PRE_APPLIED, PRE_APPLIED -> NONE, PENDING -> REJECTED/EXECUTED, EXECUTED -> REJECTED/COMPLETED, COMPLETED -> NONE, REJECTED -> NONE, PRE_APPLIED
      * - NONE: 대출 상품 선택 전
      * - PRE_APPLIED: 신청 접수 중
      * - PENDING: 심사 중
@@ -95,7 +95,7 @@ public class LoanApplication {
                 (currentStatus == LoanApplicationStatus.PENDING && (newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.EXECUTED)) ||
                 (currentStatus == LoanApplicationStatus.EXECUTED && newStatus == LoanApplicationStatus.REJECTED || newStatus == LoanApplicationStatus.COMPLETED) ||
                 (currentStatus == LoanApplicationStatus.COMPLETED && newStatus == LoanApplicationStatus.NONE) ||
-                (currentStatus == LoanApplicationStatus.REJECTED && newStatus == LoanApplicationStatus.NONE);
+                (currentStatus == LoanApplicationStatus.REJECTED && (newStatus == LoanApplicationStatus.NONE || newStatus == LoanApplicationStatus.PRE_APPLIED));
     }
 
     /**

--- a/src/main/java/com/flexrate/flexrate_back/member/application/LoginService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/LoginService.java
@@ -46,7 +46,7 @@ public class LoginService {
         String accessToken = jwtTokenProvider.generateToken(member, Duration.ofHours(2));  // 2시간 만료
         String refreshToken = jwtTokenProvider.generateToken(member, Duration.ofDays(7));  // 7일 만료
         String redisKey = "refreshToken:" + refreshToken;
-        stringRedisUtil.set(redisKey, String.valueOf(member.getMemberId()), Duration.ofDays(7));
+        stringRedisUtil.set(redisKey, String.valueOf(member.getMemberId()), Duration.ofSeconds(60));
 
         return LoginResponseDTO.builder()
                 .userId(member.getMemberId())
@@ -54,6 +54,7 @@ public class LoginService {
                 .email(member.getEmail())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .role(member.getRole())
                 .challenge("")
                 .build();
     }
@@ -103,6 +104,7 @@ public class LoginService {
                 .email(member.getEmail())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .role(member.getRole())
                 .challenge("")
                 .build();
     }
@@ -145,6 +147,7 @@ public class LoginService {
                 .email(member.getEmail())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .role(member.getRole())
                 .challenge("")
                 .build();
     }

--- a/src/main/java/com/flexrate/flexrate_back/member/dto/LoginResponseDTO.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/dto/LoginResponseDTO.java
@@ -1,5 +1,6 @@
 package com.flexrate.flexrate_back.member.dto;
 
+import com.flexrate.flexrate_back.member.enums.Role;
 import lombok.Builder;
 
 @Builder
@@ -9,5 +10,6 @@ public record LoginResponseDTO(
         String email,
         String accessToken,
         String refreshToken,
+        Role role,
         String challenge
 ) {}


### PR DESCRIPTION
## 🔥 Related Issues

- close #135 

## 💜 작업 내용

- [x] 로그인 성공 시, 멤버 권한 응답 데이터에 추가
- [x] 대출 거절 상태에서 재신청시, REJECTED -> PRE_APPLIED 상태 변경 허용

