### PR TITLE
fix: 특정 고객의 상세 조회 불가 오류 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
+++ b/src/main/java/com/flexrate/flexrate_back/member/application/MemberAdminService.java
@@ -148,9 +148,8 @@ public class MemberAdminService {
 
         LoanApplication app = memberQueryRepository.findLatestLoanApplication(memberId);
         Long tsCount = memberQueryRepository.countLoanTransactions(memberId);
-        float interestRate = memberQueryRepository.findLatestInterestRate(memberId);
 
-        log.info("대출/거래/이율 조회 성공 memberId={} loanAppId={}", memberId, app != null ? app.getApplicationId() : null);
+        log.info("대출/거래 조회 성공 memberId={} loanAppId={}", memberId, app != null ? app.getApplicationId() : null);
 
         boolean hasLoan = false;
         LocalDate startDate = null;
@@ -167,6 +166,8 @@ public class MemberAdminService {
         // app이 null이 아니고, 실행된 대출일 때만 계산
         if (app != null && LoanApplicationStatus.EXECUTED.equals(app.getStatus())) {
             hasLoan = true;
+
+            float interestRate = memberQueryRepository.findLatestInterestRate(memberId);
 
             // 날짜 처리
             if (app.getStartDate() != null) {


### PR DESCRIPTION
## 🔥 Related Issues

- close #141 

## 💜 작업 내용

- [x] 상세 조회 로직 수정

## ✅ PR Point

- 상세 조회에서 특정 멤버들의 페이지가 뜨지 않는 것을 확인했습니다. 주요 원인은 두 가지로 첫번째는 hasLoan이 true인 회원임에도 interest 더미데이터가 누락된 경우이고, 두번째는 hasLoan이 false여서 interest 값이 불필요한 회원들에 대해서도 상세 조회 로직에서 hasLoan 여부를 확인하기 전에 interest 조회를 먼저 수행하여 null 값으로 인한 오류가 발생한 경우입니다. 이를 해결하기 위해 더미데이터를 추가로 넣어주고 상세 조회 로직에서 interest 조회의 위치를 옮겼습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
두번째 경우에 해당하는 멤버의 페이지가 정상 조회됨을 확인
![image](https://github.com/user-attachments/assets/ee3aa811-24fd-462e-a309-b19ba376da62)
