### PR TITLE
fix: 신용점수 산정 로직 수정

### DIFF
--- a/src/main/java/com/flexrate/flexrate_back/financialdata/application/UserFinancialDataService.java
+++ b/src/main/java/com/flexrate/flexrate_back/financialdata/application/UserFinancialDataService.java
@@ -50,6 +50,28 @@ public class UserFinancialDataService {
         log.info("LoanApplication 조회 완료: applicationId={}", loanApplication.getApplicationId());
         log.info("현재 LoanApplication의 신용점수: {}", loanApplication.getCreditScore());
 
+        // 기존 신용점수가 있는지 확인
+        Integer existingCreditScore = loanApplication.getCreditScore();
+        if (existingCreditScore != null && existingCreditScore > 0) {
+            log.info("=== 기존 신용점수 존재 ===");
+            log.info("기존 신용점수: {}", existingCreditScore);
+
+            // -2 ~ +2 범위의 랜덤 변동값 생성 (기본값 500 유지)
+            int variation = getRandomInt(-2, 2);
+            int updatedScore = Math.max(500, Math.min(existingCreditScore + variation, 1000));
+
+            log.info("변동값: {}, 업데이트된 점수: {}", variation, updatedScore);
+
+            loanApplication.patchCreditScore(updatedScore);
+            log.info("LoanApplication 신용점수 업데이트 완료: {}", updatedScore);
+
+            member.updateCreditScoreEvaluated(true);
+            log.info("Member creditScoreEvaluated 업데이트 완료");
+
+            log.info("=== 기존 신용점수 기반 간단 업데이트 완료 ===");
+            return updatedScore;
+        }
+
         List<UserFinancialData> financialDataList = member.getFinancialData();
 
         // 평가 요소별 랜덤 값 생성 (기준 반영)


### PR DESCRIPTION
## 🔥 Related Issues

- close #143 

## 💜 작업 내용

- [x] 신용점수 산정 로직 수정 

## ✅ PR Point

- 랜덤값으로 인해 평가를 다시 받을 때마다 기존 점수와 비교했을 때 변동 폭이 너무 크므로 로직을 추가하여 해결했습니다.

## ☀ 스크린샷 / GIF / 화면 녹화
기존 점수
![image](https://github.com/user-attachments/assets/6cd16225-8656-4ff5-a724-b4ff25a64e1b)

재평가 시도 시
![image](https://github.com/user-attachments/assets/ce962f97-7f65-4ee1-afe9-73cfc8a614da)
![image](https://github.com/user-attachments/assets/8892fb38-4eec-41a1-99df-42dee2e5bbd5)


